### PR TITLE
Security/http2 one shot body cap

### DIFF
--- a/extension/src/server/http2.c
+++ b/extension/src/server/http2.c
@@ -38,6 +38,7 @@
 #define KING_SERVER_HTTP2_CLIENT_PREFACE "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 #define KING_SERVER_HTTP2_CLIENT_PREFACE_LEN 24
 #define KING_SERVER_HTTP2_MAX_FRAME_PAYLOAD_BYTES 1048576
+#define KING_SERVER_HTTP2_MAX_REQUEST_BODY_BYTES 1048576
 
 #define KING_SERVER_HTTP2_FRAME_DATA 0x0
 #define KING_SERVER_HTTP2_FRAME_HEADERS 0x1
@@ -58,6 +59,7 @@ typedef struct _king_server_http2_request_state {
     zend_string *path;
     zend_string *scheme;
     zend_string *authority;
+    size_t body_bytes;
     uint32_t stream_id;
     zend_bool headers_initialized;
 } king_server_http2_request_state;
@@ -1474,6 +1476,17 @@ static zend_result king_server_http2_handle_wire_request(
                 }
 
                 if (ZSTR_LEN(payload) > 0) {
+                    if (state.body_bytes > KING_SERVER_HTTP2_MAX_REQUEST_BODY_BYTES - ZSTR_LEN(payload)) {
+                        zend_string_release(payload);
+                        king_server_local_set_errorf(
+                            "%s() received an HTTP/2 request body that exceeds the active one-shot limit.",
+                            function_name
+                        );
+                        king_server_http2_request_state_dtor(&state);
+                        return FAILURE;
+                    }
+
+                    state.body_bytes += ZSTR_LEN(payload);
                     smart_str_appendl(&state.body, ZSTR_VAL(payload), ZSTR_LEN(payload));
                 }
 

--- a/extension/tests/464-http2-one-shot-request-body-cap-contract.phpt
+++ b/extension/tests/464-http2-one-shot-request-body-cap-contract.phpt
@@ -1,0 +1,40 @@
+--TEST--
+King HTTP/2 one-shot listener rejects cumulative request bodies above the active one-shot limit
+--FILE--
+<?php
+require __DIR__ . '/http2_server_wire_helper.inc';
+
+$server = king_http2_server_wire_start_server();
+$clientError = null;
+$capture = [];
+
+try {
+    try {
+        king_http2_server_wire_request_retry($server['port'], [
+            'method' => 'POST',
+            'path' => '/wire?room=oversized',
+            'headers' => [
+                'x-mode' => 'oversized-h2c-body',
+            ],
+            'body_frames' => [
+                str_repeat('a', 600000),
+                str_repeat('b', 500000),
+            ],
+        ]);
+    } catch (RuntimeException $e) {
+        $clientError = $e->getMessage();
+    }
+} finally {
+    $capture = king_http2_server_wire_stop_server($server);
+}
+
+var_dump($clientError !== null);
+var_dump($capture['listen_result']);
+var_dump($capture['listen_error']);
+var_dump(!isset($capture['request']));
+?>
+--EXPECT--
+bool(true)
+bool(false)
+string(103) "king_http2_server_listen_once() received an HTTP/2 request body that exceeds the active one-shot limit."
+bool(true)

--- a/extension/tests/http2_server_wire_helper.inc
+++ b/extension/tests/http2_server_wire_helper.inc
@@ -234,6 +234,26 @@ function king_http2_wire_frame(int $type, int $flags, int $streamId, string $pay
         . $payload;
 }
 
+function king_http2_wire_write_all($stream, string $buffer, string $label): void
+{
+    $written = 0;
+    $length = strlen($buffer);
+
+    while ($written < $length) {
+        $chunk = fwrite($stream, substr($buffer, $written));
+        if ($chunk === false || $chunk === 0) {
+            $meta = stream_get_meta_data($stream);
+            if (($meta['timed_out'] ?? false) === true) {
+                throw new RuntimeException("timed out while writing $label");
+            }
+
+            throw new RuntimeException("failed while writing $label");
+        }
+
+        $written += $chunk;
+    }
+}
+
 function king_http2_wire_read_exact($stream, int $bytes, string $label): string
 {
     $data = '';
@@ -289,8 +309,14 @@ function king_http2_server_wire_request_retry(int $port, array $request, int $ti
             $method = strtoupper((string) ($request['method'] ?? 'GET'));
             $path = (string) ($request['path'] ?? '/');
             $body = (string) ($request['body'] ?? '');
+            $bodyFrames = $request['body_frames'] ?? null;
             $headers = $request['headers'] ?? [];
             $authority = '127.0.0.1:' . $port;
+
+            if ($bodyFrames !== null && !is_array($bodyFrames)) {
+                fclose($client);
+                throw new RuntimeException('body_frames must be an array when provided');
+            }
 
             $headerBlock = $method === 'POST' ? "\x83" : "\x82";
             $headerBlock .= "\x86";
@@ -307,15 +333,26 @@ function king_http2_server_wire_request_retry(int $port, array $request, int $ti
             $wire .= king_http2_wire_frame(0x4, 0x0, 0, '');
             $wire .= king_http2_wire_frame(
                 0x1,
-                $body === '' ? 0x5 : 0x4,
+                ($body === '' && ($bodyFrames === null || $bodyFrames === [])) ? 0x5 : 0x4,
                 1,
                 $headerBlock
             );
-            if ($body !== '') {
+
+            if ($bodyFrames !== null && $bodyFrames !== []) {
+                $lastIndex = count($bodyFrames) - 1;
+                foreach (array_values($bodyFrames) as $index => $frameBody) {
+                    $wire .= king_http2_wire_frame(
+                        0x0,
+                        $index === $lastIndex ? 0x1 : 0x0,
+                        1,
+                        (string) $frameBody
+                    );
+                }
+            } elseif ($body !== '') {
                 $wire .= king_http2_wire_frame(0x0, 0x1, 1, $body);
             }
 
-            fwrite($client, $wire);
+            king_http2_wire_write_all($client, $wire, 'HTTP/2 wire request');
 
             $responseHeaders = [];
             $responseBody = '';


### PR DESCRIPTION
Title:
Cap HTTP/2 one-shot request bodies

Description:
This PR fixes an unbounded-memory DoS risk in the on-wire HTTP/2 one-shot listener.

Included:
- a cumulative HTTP/2 request-body size cap
- rejection of oversized DATA-frame streams before the body buffer can grow without bound
- updated wire-test helper coverage for fragmented DATA frames
- a regression contract proving that oversized HTTP/2 one-shot request bodies are rejected

Impact:
- closes the missing aggregate body-size limit in the HTTP/2 one-shot listener
- aligns HTTP/2 request-body handling with the bounded-body expectations already enforced elsewhere
