### PR TITLE
Security/http3 one shot body completion

### DIFF
--- a/extension/src/server/http3.c
+++ b/extension/src/server/http3.c
@@ -1590,10 +1590,6 @@ static zend_result king_server_http3_process_events(
                     return FAILURE;
                 }
 
-                if (!king_server_http3_quiche.quiche_h3_event_headers_has_more_frames_fn(event)) {
-                    *request_complete = true;
-                }
-
                 break;
             }
 

--- a/extension/tests/449-http3-one-shot-delayed-body-completion-contract.phpt
+++ b/extension/tests/449-http3-one-shot-delayed-body-completion-contract.phpt
@@ -1,0 +1,73 @@
+--TEST--
+King HTTP/3 one-shot listener waits for DATA and FIN before invoking the handler
+--SKIPIF--
+<?php
+if (trim((string) shell_exec('command -v openssl')) === '') {
+    echo "skip openssl is required for the on-wire HTTP/3 fixture";
+}
+
+if (trim((string) shell_exec('command -v cargo')) === '') {
+    echo "skip cargo is required to build the delayed HTTP/3 body client helper";
+}
+
+$library = getenv('KING_QUICHE_LIBRARY');
+if (!is_string($library) || $library === '' || !is_file($library)) {
+    echo "skip KING_QUICHE_LIBRARY must point at a prebuilt libquiche runtime";
+}
+?>
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+require __DIR__ . '/http3_test_helper.inc';
+require __DIR__ . '/http3_server_wire_helper.inc';
+
+$fixture = king_http3_create_fixture([]);
+
+try {
+    $run = king_http3_one_shot_result_with_retry(
+        static fn () => king_http3_server_wire_start_server($fixture['cert'], $fixture['key']),
+        'king_http3_server_wire_stop_server',
+        static fn (array $server) => king_http3_send_delayed_body_request(
+            'https://localhost:' . $server['port'] . '/wire?room=delayed',
+            'payload',
+            250
+        ),
+        static fn (array $response) => $response['status'] === 201
+            && $response['body'] === 'reply:payload'
+            && $response['early_response'] === false
+    );
+    $response = $run['result'];
+    $capture = $run['capture'];
+} finally {
+    king_http3_destroy_fixture($fixture);
+}
+
+var_dump($response['status']);
+var_dump($response['body']);
+var_dump($response['early_response']);
+var_dump($capture['listen_result']);
+var_dump($capture['listen_error']);
+var_dump($capture['request']['method']);
+var_dump($capture['request']['uri']);
+echo $capture['request']['host'], "\n";
+var_dump($capture['request']['body']);
+var_dump($capture['request']['mode']);
+var_dump($capture['request']['transport_backend_before']);
+var_dump($capture['request']['alpn_before']);
+var_dump($capture['post_stats']['state']);
+?>
+--EXPECTF--
+int(201)
+string(13) "reply:payload"
+bool(false)
+bool(true)
+string(0) ""
+string(4) "POST"
+string(18) "/wire?room=delayed"
+localhost:%d
+string(7) "payload"
+string(12) "delayed-body"
+string(19) "server_http3_socket"
+string(2) "h3"
+string(6) "closed"

--- a/extension/tests/http3_delayed_body_client.rs
+++ b/extension/tests/http3_delayed_body_client.rs
@@ -1,0 +1,309 @@
+use quiche::h3::NameValue;
+
+use ring::rand::SecureRandom;
+use ring::rand::SystemRandom;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+use std::time::Instant;
+
+const MAX_DATAGRAM_SIZE: usize = 1350;
+
+fn main() {
+    if let Err(message) = run() {
+        eprintln!("{message}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = std::env::args();
+    let cmd = args
+        .next()
+        .unwrap_or_else(|| "king-http3-delayed-body-client".to_string());
+    let url_text = args
+        .next()
+        .ok_or_else(|| format!("usage: {cmd} <url> <delay-ms> <body>"))?;
+    let delay_ms = args
+        .next()
+        .ok_or_else(|| format!("usage: {cmd} <url> <delay-ms> <body>"))?
+        .parse::<u64>()
+        .map_err(|err| format!("invalid delay: {err}"))?;
+    let body = args
+        .next()
+        .ok_or_else(|| format!("usage: {cmd} <url> <delay-ms> <body>"))?
+        .into_bytes();
+
+    let url = url::Url::parse(&url_text).map_err(|err| format!("invalid url: {err}"))?;
+    let peer_addr = *url
+        .socket_addrs(|| None)
+        .map_err(|err| format!("failed to resolve peer address: {err}"))?
+        .first()
+        .ok_or_else(|| "no peer address resolved".to_string())?;
+
+    let bind_addr = match peer_addr {
+        SocketAddr::V4(_) => "0.0.0.0:0",
+        SocketAddr::V6(_) => "[::]:0",
+    };
+
+    let mut socket = mio::net::UdpSocket::bind(
+        bind_addr
+            .parse()
+            .map_err(|err| format!("invalid bind address: {err}"))?,
+    )
+    .map_err(|err| format!("failed to bind UDP socket: {err}"))?;
+
+    let mut poll = mio::Poll::new().map_err(|err| format!("failed to create poll: {err}"))?;
+    let mut events = mio::Events::with_capacity(1024);
+
+    poll.registry()
+        .register(&mut socket, mio::Token(0), mio::Interest::READABLE)
+        .map_err(|err| format!("failed to register socket: {err}"))?;
+
+    let mut config =
+        quiche::Config::new(quiche::PROTOCOL_VERSION).map_err(|err| format!("{err:?}"))?;
+    config.verify_peer(false);
+    config
+        .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+        .map_err(|err| format!("failed to set ALPN: {err:?}"))?;
+    config.set_max_idle_timeout(5000);
+    config.set_max_recv_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_max_send_udp_payload_size(MAX_DATAGRAM_SIZE);
+    config.set_initial_max_data(1_000_000);
+    config.set_initial_max_stream_data_bidi_local(1_000_000);
+    config.set_initial_max_stream_data_bidi_remote(1_000_000);
+    config.set_initial_max_stream_data_uni(1_000_000);
+    config.set_initial_max_streams_bidi(16);
+    config.set_initial_max_streams_uni(16);
+    config.set_disable_active_migration(true);
+
+    let mut scid = [0_u8; quiche::MAX_CONN_ID_LEN];
+    SystemRandom::new()
+        .fill(&mut scid)
+        .map_err(|_| "failed to generate QUIC source connection id".to_string())?;
+    let scid = quiche::ConnectionId::from_ref(&scid);
+
+    let local_addr = socket
+        .local_addr()
+        .map_err(|err| format!("failed to get local address: {err}"))?;
+    let mut conn = quiche::connect(url.domain(), &scid, local_addr, peer_addr, &mut config)
+        .map_err(|err| format!("failed to start QUIC connection: {err:?}"))?;
+
+    let mut out = [0_u8; MAX_DATAGRAM_SIZE];
+    let mut buf = [0_u8; 65535];
+
+    let (written, send_info) = conn
+        .send(&mut out)
+        .map_err(|err| format!("initial QUIC send failed: {err:?}"))?;
+    socket
+        .send_to(&out[..written], send_info.to)
+        .map_err(|err| format!("initial UDP send failed: {err}"))?;
+
+    let h3_config = quiche::h3::Config::new()
+        .map_err(|err| format!("failed to create HTTP/3 config: {err:?}"))?;
+
+    let mut h3_conn: Option<quiche::h3::Connection> = None;
+    let mut headers_sent = false;
+    let mut body_sent = false;
+    let mut body_offset = 0_usize;
+    let mut request_stream_id = 0_u64;
+    let mut headers_sent_at = Instant::now();
+    let body_deadline = Duration::from_millis(delay_ms);
+
+    let mut response_status = 0_u16;
+    let mut response_body = Vec::new();
+    let mut response_finished = false;
+    let mut early_response = false;
+
+    let authority = match url.port() {
+        Some(port) => format!(
+            "{}:{}",
+            url.host_str().ok_or_else(|| "URL host missing".to_string())?,
+            port
+        ),
+        None => url
+            .host_str()
+            .ok_or_else(|| "URL host missing".to_string())?
+            .to_string(),
+    };
+
+    let mut path = url.path().to_string();
+    if let Some(query) = url.query() {
+        path.push('?');
+        path.push_str(query);
+    }
+    if path.is_empty() {
+        path.push('/');
+    }
+
+    let content_length = body.len().to_string();
+    let request = vec![
+        quiche::h3::Header::new(b":method", b"POST"),
+        quiche::h3::Header::new(b":scheme", url.scheme().as_bytes()),
+        quiche::h3::Header::new(b":authority", authority.as_bytes()),
+        quiche::h3::Header::new(b":path", path.as_bytes()),
+        quiche::h3::Header::new(b"user-agent", b"king-http3-delayed-body-client"),
+        quiche::h3::Header::new(b"content-length", content_length.as_bytes()),
+        quiche::h3::Header::new(b"x-mode", b"delayed-body"),
+    ];
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+
+    while Instant::now() < deadline {
+        let poll_timeout = match conn.timeout() {
+            Some(timeout) => {
+                if headers_sent && !body_sent {
+                    let remaining = body_deadline.saturating_sub(headers_sent_at.elapsed());
+                    Some(timeout.min(remaining.min(Duration::from_millis(50))))
+                } else {
+                    Some(timeout.min(Duration::from_millis(50)))
+                }
+            },
+            None => Some(Duration::from_millis(50)),
+        };
+
+        poll.poll(&mut events, poll_timeout)
+            .map_err(|err| format!("poll failed: {err}"))?;
+
+        if events.is_empty() {
+            conn.on_timeout();
+        }
+
+        'read: loop {
+            if events.is_empty() {
+                break 'read;
+            }
+
+            let (len, from) = match socket.recv_from(&mut buf) {
+                Ok(value) => value,
+                Err(err) => {
+                    if err.kind() == std::io::ErrorKind::WouldBlock {
+                        break 'read;
+                    }
+
+                    return Err(format!("recv_from failed: {err}"));
+                },
+            };
+
+            let recv_info = quiche::RecvInfo {
+                to: local_addr,
+                from,
+            };
+
+            match conn.recv(&mut buf[..len], recv_info) {
+                Ok(_) => (),
+                Err(quiche::Error::Done) => break 'read,
+                Err(err) => return Err(format!("QUIC recv failed: {err:?}")),
+            }
+        }
+
+        if conn.is_closed() && response_status == 0 {
+            return Err("connection closed before any HTTP/3 response arrived".to_string());
+        }
+
+        if conn.is_established() && h3_conn.is_none() {
+            h3_conn = Some(
+                quiche::h3::Connection::with_transport(&mut conn, &h3_config)
+                    .map_err(|err| format!("failed to create HTTP/3 connection: {err:?}"))?,
+            );
+        }
+
+        if let Some(h3) = h3_conn.as_mut() {
+            if !headers_sent {
+                request_stream_id = h3
+                    .send_request(&mut conn, &request, false)
+                    .map_err(|err| format!("send_request failed: {err:?}"))?;
+                headers_sent = true;
+                headers_sent_at = Instant::now();
+            }
+
+            if headers_sent && !body_sent && headers_sent_at.elapsed() >= body_deadline {
+                let sent = h3
+                    .send_body(&mut conn, request_stream_id, &body[body_offset..], true)
+                    .map_err(|err| format!("send_body failed: {err:?}"))?;
+                body_offset += sent;
+                if body_offset == body.len() {
+                    body_sent = true;
+                }
+            }
+
+            loop {
+                match h3.poll(&mut conn) {
+                    Ok((_stream_id, quiche::h3::Event::Headers { list, .. })) => {
+                        if !body_sent {
+                            early_response = true;
+                        }
+
+                        for header in &list {
+                            if header.name() == b":status" {
+                                response_status = std::str::from_utf8(header.value())
+                                    .map_err(|err| format!("invalid response status bytes: {err}"))?
+                                    .parse::<u16>()
+                                    .map_err(|err| format!("invalid response status: {err}"))?;
+                            }
+                        }
+                    },
+                    Ok((stream_id, quiche::h3::Event::Data)) => {
+                        if !body_sent {
+                            early_response = true;
+                        }
+
+                        loop {
+                            match h3.recv_body(&mut conn, stream_id, &mut buf) {
+                                Ok(read) => response_body.extend_from_slice(&buf[..read]),
+                                Err(quiche::h3::Error::Done) => break,
+                                Err(err) => return Err(format!("recv_body failed: {err:?}")),
+                            }
+                        }
+                    },
+                    Ok((_stream_id, quiche::h3::Event::Finished)) => {
+                        if !body_sent {
+                            early_response = true;
+                        }
+
+                        response_finished = true;
+                        conn.close(true, 0x100, b"done").ok();
+                    },
+                    Ok((_stream_id, quiche::h3::Event::Reset(err))) => {
+                        return Err(format!("request stream reset by peer: {err:?}"));
+                    },
+                    Ok((_stream_id, quiche::h3::Event::PriorityUpdate)) => unreachable!(),
+                    Ok((_goaway_id, quiche::h3::Event::GoAway)) => (),
+                    Err(quiche::h3::Error::Done) => break,
+                    Err(err) => return Err(format!("HTTP/3 polling failed: {err:?}")),
+                }
+            }
+        }
+
+        flush_egress(&mut socket, &mut conn, &mut out)?;
+
+        if response_finished {
+            println!("STATUS {}", response_status);
+            println!("EARLY_RESPONSE {}", if early_response { 1 } else { 0 });
+            println!("BODY {}", String::from_utf8_lossy(&response_body));
+            return Ok(());
+        }
+    }
+
+    Err("timed out waiting for delayed-body HTTP/3 response".to_string())
+}
+
+fn flush_egress(
+    socket: &mut mio::net::UdpSocket,
+    conn: &mut quiche::Connection,
+    out: &mut [u8; MAX_DATAGRAM_SIZE],
+) -> Result<(), String> {
+    loop {
+        let (written, send_info) = match conn.send(out) {
+            Ok(value) => value,
+            Err(quiche::Error::Done) => break,
+            Err(err) => return Err(format!("QUIC send failed: {err:?}")),
+        };
+
+        socket
+            .send_to(&out[..written], send_info.to)
+            .map_err(|err| format!("UDP send failed: {err}"))?;
+    }
+
+    Ok(())
+}

--- a/extension/tests/http3_test_helper.inc
+++ b/extension/tests/http3_test_helper.inc
@@ -498,6 +498,109 @@ function king_http3_failure_peer_binary(): string
     return $binary;
 }
 
+function king_http3_delayed_body_client_binary(): string
+{
+    $root = dirname(dirname(__DIR__));
+    $template = __DIR__ . '/http3_delayed_body_client.rs';
+    $manifest = $root . '/quiche/apps/Cargo.toml';
+    $source = $root . '/quiche/apps/src/bin/king-http3-delayed-body-client.rs';
+    $binary = $root . '/quiche/target/release/king-http3-delayed-body-client';
+
+    if (trim((string) shell_exec('command -v cargo')) === '') {
+        throw new RuntimeException('cargo is required to build the HTTP/3 delayed body client helper');
+    }
+
+    if (!is_file($template)) {
+        throw new RuntimeException('missing tracked HTTP/3 delayed body client template');
+    }
+
+    $templateContents = file_get_contents($template);
+    if (!is_string($templateContents) || $templateContents === '') {
+        throw new RuntimeException('failed to read tracked HTTP/3 delayed body client template');
+    }
+
+    $currentSource = is_file($source) ? file_get_contents($source) : false;
+    if (!is_string($currentSource) || $currentSource !== $templateContents) {
+        if (file_put_contents($source, $templateContents) !== strlen($templateContents)) {
+            throw new RuntimeException('failed to synchronize tracked HTTP/3 delayed body client source');
+        }
+    }
+
+    if (is_file($binary) && filemtime($binary) >= max(filemtime($source), filemtime($template))) {
+        return $binary;
+    }
+
+    $command = sprintf(
+        'cargo build --manifest-path %s --release --locked --bin king-http3-delayed-body-client 2>&1',
+        escapeshellarg($manifest)
+    );
+
+    exec($command, $output, $exitCode);
+    if ($exitCode !== 0 || !is_file($binary)) {
+        throw new RuntimeException(
+            "failed to build HTTP/3 delayed body client helper:\n" . implode("\n", $output)
+        );
+    }
+
+    return $binary;
+}
+
+function king_http3_send_delayed_body_request(string $url, string $body, int $delayMs = 250): array
+{
+    $binary = king_http3_delayed_body_client_binary();
+    $command = [$binary, $url, (string) $delayMs, $body];
+    $process = proc_open($command, [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ], $pipes);
+
+    if (!is_resource($process)) {
+        throw new RuntimeException('failed to launch delayed HTTP/3 body client helper');
+    }
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+
+    foreach ($pipes as $pipe) {
+        fclose($pipe);
+    }
+
+    $exitCode = proc_close($process);
+    if ($exitCode !== 0) {
+        throw new RuntimeException(
+            "delayed HTTP/3 body client helper failed:\n" . trim($stdout . "\n" . $stderr)
+        );
+    }
+
+    $result = [
+        'status' => 0,
+        'body' => '',
+        'early_response' => false,
+    ];
+
+    foreach (preg_split('/\r?\n/', trim($stdout)) as $line) {
+        if (!is_string($line) || $line === '') {
+            continue;
+        }
+
+        if (strncmp($line, 'STATUS ', 7) === 0) {
+            $result['status'] = (int) substr($line, 7);
+            continue;
+        }
+
+        if (strncmp($line, 'BODY ', 5) === 0) {
+            $result['body'] = substr($line, 5);
+            continue;
+        }
+
+        if (strncmp($line, 'EARLY_RESPONSE ', 15) === 0) {
+            $result['early_response'] = substr($line, 15) === '1';
+        }
+    }
+
+    return $result;
+}
+
 function king_http3_start_failure_peer(
     string $mode,
     string $certFile,


### PR DESCRIPTION
Title:
Wait for full HTTP/3 request completion

Description:
This PR fixes early handler invocation in the HTTP/3 one-shot listener.

Included:
- request completion now waits for the actual HTTP/3 stream finish signal instead of treating completed HEADERS as a complete request
- a delayed-body on-wire regression that sends HEADERS first, delays DATA/FIN, and proves the handler is not invoked early
- helper support for the delayed-body HTTP/3 test client

Impact:
- prevents handlers from observing truncated or empty bodies while request data is still in flight
- restores correct request-completion semantics for one-shot HTTP/3 handling
