### PR TITLE
Security/object store cloud metadata header sanitization

### DIFF
--- a/extension/include/object_store/object_store_internal.h
+++ b/extension/include/object_store/object_store_internal.h
@@ -114,6 +114,12 @@ int king_object_store_meta_write(const char *object_id, const king_object_metada
 int king_object_store_meta_read(const char *object_id, king_object_metadata_t *metadata);
 void king_object_store_meta_remove(const char *object_id);
 int king_object_store_runtime_metadata_cache_read(const char *object_id, king_object_metadata_t *metadata);
+int king_object_store_http_header_value_validate(
+    const char *field_name,
+    const char *value,
+    char *error,
+    size_t error_size
+);
 
 /* Rehydrate runtime stats from disk on init */
 void king_object_store_rehydrate_stats(void);

--- a/extension/src/core/introspection/object_store/registry.inc
+++ b/extension/src/core/introspection/object_store/registry.inc
@@ -51,6 +51,41 @@ static zend_bool king_object_store_registry_copy_string_option(
     return 1;
 }
 
+static zend_bool king_object_store_registry_validate_http_header_option(
+    const char *key,
+    const char *value,
+    const char *function_name
+)
+{
+    char error[256];
+    int result;
+
+    if (value == NULL || value[0] == '\0') {
+        return 1;
+    }
+
+    result = king_object_store_http_header_value_validate(
+        key,
+        value,
+        error,
+        sizeof(error)
+    );
+    if (result == SUCCESS) {
+        return 1;
+    }
+
+    zend_throw_exception_ex(
+        king_ce_validation_exception,
+        0,
+        "%s() %s",
+        function_name,
+        error[0] != '\0'
+            ? error
+            : "Object-store metadata contains unsupported CR/LF characters for cloud HTTP headers."
+    );
+    return 0;
+}
+
 static php_stream *king_object_store_registry_fetch_stream_resource(
     zval *stream_zv,
     uint32_t arg_num,
@@ -671,6 +706,18 @@ static zend_bool king_object_store_registry_apply_put_metadata_options(
         return 0;
     }
 
+    if (!king_object_store_registry_validate_http_header_option(
+            "content_type",
+            metadata->content_type,
+            function_name
+        ) || !king_object_store_registry_validate_http_header_option(
+            "content_encoding",
+            metadata->content_encoding,
+            function_name
+        )) {
+        return 0;
+    }
+
     return 1;
 }
 
@@ -1083,15 +1130,15 @@ PHP_FUNCTION(king_object_store_put)
         RETURN_THROWS();
     }
 
-    if (!king_object_store_registry_check_write_preconditions(
-            ZSTR_VAL(object_id),
-            options,
-            "king_object_store_put"
-        )
-        || !king_object_store_registry_apply_put_options(
+    if (!king_object_store_registry_apply_put_options(
             options,
             payload,
             &metadata,
+            "king_object_store_put"
+        )
+        || !king_object_store_registry_check_write_preconditions(
+            ZSTR_VAL(object_id),
+            options,
             "king_object_store_put"
         )) {
         king_object_store_registry_release_mutation_lock(&mutation_lock_fd);
@@ -1177,9 +1224,9 @@ PHP_FUNCTION(king_object_store_put_from_stream)
 
     memset(&metadata, 0, sizeof(metadata));
     strncpy(metadata.object_id, ZSTR_VAL(object_id), sizeof(metadata.object_id) - 1);
-    if (!king_object_store_registry_check_write_preconditions(
-            ZSTR_VAL(object_id),
+    if (!king_object_store_registry_apply_put_metadata_options(
             options,
+            &metadata,
             "king_object_store_put_from_stream"
         )) {
         king_object_store_registry_release_mutation_lock(&mutation_lock_fd);
@@ -1199,7 +1246,12 @@ PHP_FUNCTION(king_object_store_put_from_stream)
     }
     staged = 1;
 
-    if (!king_object_store_registry_validate_capacity_for_size(
+    if (!king_object_store_registry_check_write_preconditions(
+            ZSTR_VAL(object_id),
+            options,
+            "king_object_store_put_from_stream"
+        )
+        || !king_object_store_registry_validate_capacity_for_size(
             ZSTR_VAL(object_id),
             content_length,
             "king_object_store_put_from_stream"
@@ -1210,11 +1262,7 @@ PHP_FUNCTION(king_object_store_put_from_stream)
     }
 
     metadata.content_length = content_length;
-    if (!king_object_store_registry_apply_put_metadata_options(
-            options,
-            &metadata,
-            "king_object_store_put_from_stream"
-        ) || !king_object_store_registry_apply_put_integrity_option(
+    if (!king_object_store_registry_apply_put_integrity_option(
             options,
             computed_sha256,
             &metadata,
@@ -1299,14 +1347,14 @@ PHP_FUNCTION(king_object_store_begin_resumable_upload)
         RETURN_THROWS();
     }
 
-    if (!king_object_store_registry_check_write_preconditions(
-            ZSTR_VAL(object_id),
-            options,
-            "king_object_store_begin_resumable_upload"
-        )
-        || !king_object_store_registry_apply_put_metadata_options(
+    if (!king_object_store_registry_apply_put_metadata_options(
             options,
             &metadata,
+            "king_object_store_begin_resumable_upload"
+        )
+        || !king_object_store_registry_check_write_preconditions(
+            ZSTR_VAL(object_id),
+            options,
             "king_object_store_begin_resumable_upload"
         )
         || !king_object_store_registry_copy_sha256_option(

--- a/extension/src/object_store/internal/cloud_azure_runtime.inc
+++ b/extension/src/object_store/internal/cloud_azure_runtime.inc
@@ -378,26 +378,61 @@ static zend_result king_object_store_azure_http_request(
     headers = king_object_store_libcurl.curl_slist_append_fn(headers, auth_header);
 
     if (body != NULL || strcmp(method, "PUT") == 0) {
-        char content_type_header[160];
-
         if (request_metadata != NULL && request_metadata->content_type[0] != '\0') {
-            snprintf(content_type_header, sizeof(content_type_header), "Content-Type: %s", request_metadata->content_type);
-            headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_type_header);
+            int header_result = king_object_store_append_named_http_header(
+                &headers,
+                "Content-Type",
+                "content_type",
+                request_metadata->content_type,
+                error,
+                error_size
+            );
+
+            if (header_result != SUCCESS) {
+                king_object_store_libcurl.curl_slist_free_all_fn(headers);
+                king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+                smart_str_free(&url);
+                return header_result;
+            }
         } else {
             headers = king_object_store_libcurl.curl_slist_append_fn(headers, "Content-Type: application/octet-stream");
         }
     }
     if (request_metadata != NULL && request_metadata->content_encoding[0] != '\0') {
-        char content_encoding_header[128];
+        int header_result = king_object_store_append_named_http_header(
+            &headers,
+            "Content-Encoding",
+            "content_encoding",
+            request_metadata->content_encoding,
+            error,
+            error_size
+        );
 
-        snprintf(content_encoding_header, sizeof(content_encoding_header), "Content-Encoding: %s", request_metadata->content_encoding);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_encoding_header);
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            smart_str_free(&url);
+            return header_result;
+        }
     }
     if (strcmp(method, "PUT") == 0) {
         headers = king_object_store_libcurl.curl_slist_append_fn(headers, "x-ms-blob-type: BlockBlob");
     }
     if (request_metadata != NULL) {
-        headers = king_object_store_append_metadata_headers(headers, "x-ms-meta-", request_metadata);
+        int header_result = king_object_store_append_metadata_headers(
+            &headers,
+            "x-ms-meta-",
+            request_metadata,
+            error,
+            error_size
+        );
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            smart_str_free(&url);
+            return header_result;
+        }
     }
     if (range_header != NULL && range_header[0] != '\0') {
         headers = king_object_store_libcurl.curl_slist_append_fn(headers, range_header);
@@ -695,23 +730,55 @@ static zend_result king_object_store_azure_http_request_url(
     headers = king_object_store_libcurl.curl_slist_append_fn(headers, auth_header);
 
     if (request_metadata != NULL || strcmp(method, "PUT") == 0) {
-        char content_type_header[160];
-
         if (request_metadata != NULL && request_metadata->content_type[0] != '\0') {
-            snprintf(content_type_header, sizeof(content_type_header), "Content-Type: %s", request_metadata->content_type);
-            headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_type_header);
+            int header_result = king_object_store_append_named_http_header(
+                &headers,
+                "Content-Type",
+                "content_type",
+                request_metadata->content_type,
+                error,
+                error_size
+            );
+
+            if (header_result != SUCCESS) {
+                king_object_store_libcurl.curl_slist_free_all_fn(headers);
+                king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+                return header_result;
+            }
         } else {
             headers = king_object_store_libcurl.curl_slist_append_fn(headers, "Content-Type: application/octet-stream");
         }
     }
     if (request_metadata != NULL && request_metadata->content_encoding[0] != '\0') {
-        char content_encoding_header[128];
+        int header_result = king_object_store_append_named_http_header(
+            &headers,
+            "Content-Encoding",
+            "content_encoding",
+            request_metadata->content_encoding,
+            error,
+            error_size
+        );
 
-        snprintf(content_encoding_header, sizeof(content_encoding_header), "Content-Encoding: %s", request_metadata->content_encoding);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_encoding_header);
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            return header_result;
+        }
     }
     if (request_metadata != NULL) {
-        headers = king_object_store_append_metadata_headers(headers, "x-ms-meta-", request_metadata);
+        int header_result = king_object_store_append_metadata_headers(
+            &headers,
+            "x-ms-meta-",
+            request_metadata,
+            error,
+            error_size
+        );
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            return header_result;
+        }
     }
     for (i = 0; i < extra_header_count; ++i) {
         if (extra_headers[i] != NULL && extra_headers[i][0] != '\0') {
@@ -774,4 +841,3 @@ static zend_result king_object_store_azure_http_request_url(
     king_object_store_libcurl.curl_easy_cleanup_fn(easy);
     return SUCCESS;
 }
-

--- a/extension/src/object_store/internal/cloud_gcs_runtime.inc
+++ b/extension/src/object_store/internal/cloud_gcs_runtime.inc
@@ -380,23 +380,58 @@ static zend_result king_object_store_gcs_http_request(
     headers = king_object_store_libcurl.curl_slist_append_fn(headers, auth_header);
 
     if (body != NULL || strcmp(method, "PUT") == 0) {
-        char content_type_header[160];
-
         if (request_metadata != NULL && request_metadata->content_type[0] != '\0') {
-            snprintf(content_type_header, sizeof(content_type_header), "Content-Type: %s", request_metadata->content_type);
-            headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_type_header);
+            int header_result = king_object_store_append_named_http_header(
+                &headers,
+                "Content-Type",
+                "content_type",
+                request_metadata->content_type,
+                error,
+                error_size
+            );
+
+            if (header_result != SUCCESS) {
+                king_object_store_libcurl.curl_slist_free_all_fn(headers);
+                king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+                smart_str_free(&url);
+                return header_result;
+            }
         } else {
             headers = king_object_store_libcurl.curl_slist_append_fn(headers, "Content-Type: application/octet-stream");
         }
     }
     if (request_metadata != NULL && request_metadata->content_encoding[0] != '\0') {
-        char content_encoding_header[128];
+        int header_result = king_object_store_append_named_http_header(
+            &headers,
+            "Content-Encoding",
+            "content_encoding",
+            request_metadata->content_encoding,
+            error,
+            error_size
+        );
 
-        snprintf(content_encoding_header, sizeof(content_encoding_header), "Content-Encoding: %s", request_metadata->content_encoding);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_encoding_header);
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            smart_str_free(&url);
+            return header_result;
+        }
     }
     if (request_metadata != NULL) {
-        headers = king_object_store_append_metadata_headers(headers, "x-goog-meta-", request_metadata);
+        int header_result = king_object_store_append_metadata_headers(
+            &headers,
+            "x-goog-meta-",
+            request_metadata,
+            error,
+            error_size
+        );
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            smart_str_free(&url);
+            return header_result;
+        }
     }
     if (range_header != NULL && range_header[0] != '\0') {
         headers = king_object_store_libcurl.curl_slist_append_fn(headers, range_header);
@@ -683,23 +718,55 @@ static zend_result king_object_store_gcs_http_request_url(
     headers = king_object_store_libcurl.curl_slist_append_fn(headers, auth_header);
 
     if (request_metadata != NULL || strcmp(method, "PUT") == 0) {
-        char content_type_header[160];
-
         if (request_metadata != NULL && request_metadata->content_type[0] != '\0') {
-            snprintf(content_type_header, sizeof(content_type_header), "Content-Type: %s", request_metadata->content_type);
-            headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_type_header);
+            int header_result = king_object_store_append_named_http_header(
+                &headers,
+                "Content-Type",
+                "content_type",
+                request_metadata->content_type,
+                error,
+                error_size
+            );
+
+            if (header_result != SUCCESS) {
+                king_object_store_libcurl.curl_slist_free_all_fn(headers);
+                king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+                return header_result;
+            }
         } else {
             headers = king_object_store_libcurl.curl_slist_append_fn(headers, "Content-Type: application/octet-stream");
         }
     }
     if (request_metadata != NULL && request_metadata->content_encoding[0] != '\0') {
-        char content_encoding_header[128];
+        int header_result = king_object_store_append_named_http_header(
+            &headers,
+            "Content-Encoding",
+            "content_encoding",
+            request_metadata->content_encoding,
+            error,
+            error_size
+        );
 
-        snprintf(content_encoding_header, sizeof(content_encoding_header), "Content-Encoding: %s", request_metadata->content_encoding);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_encoding_header);
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            return header_result;
+        }
     }
     if (request_metadata != NULL) {
-        headers = king_object_store_append_metadata_headers(headers, "x-goog-meta-", request_metadata);
+        int header_result = king_object_store_append_metadata_headers(
+            &headers,
+            "x-goog-meta-",
+            request_metadata,
+            error,
+            error_size
+        );
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            return header_result;
+        }
     }
     for (i = 0; i < extra_header_count; ++i) {
         if (extra_headers[i] != NULL && extra_headers[i][0] != '\0') {
@@ -762,4 +829,3 @@ static zend_result king_object_store_gcs_http_request_url(
     king_object_store_libcurl.curl_easy_cleanup_fn(easy);
     return SUCCESS;
 }
-

--- a/extension/src/object_store/internal/cloud_s3_metadata.inc
+++ b/extension/src/object_store/internal/cloud_s3_metadata.inc
@@ -299,23 +299,55 @@ static zend_result king_object_store_s3_http_request_url(
     }
 
     if (request_metadata != NULL || strcmp(method, "PUT") == 0) {
-        char content_type_header[160];
-
         if (request_metadata != NULL && request_metadata->content_type[0] != '\0') {
-            snprintf(content_type_header, sizeof(content_type_header), "Content-Type: %s", request_metadata->content_type);
-            headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_type_header);
+            int header_result = king_object_store_append_named_http_header(
+                &headers,
+                "Content-Type",
+                "content_type",
+                request_metadata->content_type,
+                error,
+                error_size
+            );
+
+            if (header_result != SUCCESS) {
+                king_object_store_libcurl.curl_slist_free_all_fn(headers);
+                king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+                return header_result;
+            }
         } else {
             headers = king_object_store_libcurl.curl_slist_append_fn(headers, "Content-Type: application/octet-stream");
         }
     }
     if (request_metadata != NULL && request_metadata->content_encoding[0] != '\0') {
-        char content_encoding_header[128];
+        int header_result = king_object_store_append_named_http_header(
+            &headers,
+            "Content-Encoding",
+            "content_encoding",
+            request_metadata->content_encoding,
+            error,
+            error_size
+        );
 
-        snprintf(content_encoding_header, sizeof(content_encoding_header), "Content-Encoding: %s", request_metadata->content_encoding);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_encoding_header);
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            return header_result;
+        }
     }
     if (request_metadata != NULL) {
-        headers = king_object_store_append_metadata_headers(headers, "x-amz-meta-", request_metadata);
+        int header_result = king_object_store_append_metadata_headers(
+            &headers,
+            "x-amz-meta-",
+            request_metadata,
+            error,
+            error_size
+        );
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            return header_result;
+        }
     }
     for (i = 0; i < extra_header_count; ++i) {
         if (extra_headers[i] != NULL && extra_headers[i][0] != '\0') {
@@ -386,4 +418,3 @@ static zend_result king_object_store_s3_http_request_url(
     king_object_store_libcurl.curl_easy_cleanup_fn(easy);
     return SUCCESS;
 }
-

--- a/extension/src/object_store/internal/cloud_s3_runtime.inc
+++ b/extension/src/object_store/internal/cloud_s3_runtime.inc
@@ -769,33 +769,58 @@ static zend_result king_object_store_s3_http_request(
     }
 
     if (body != NULL || strcmp(method, "PUT") == 0) {
-        char content_type_header[160];
-
         if (request_metadata != NULL && request_metadata->content_type[0] != '\0') {
-            snprintf(
-                content_type_header,
-                sizeof(content_type_header),
-                "Content-Type: %s",
-                request_metadata->content_type
+            int header_result = king_object_store_append_named_http_header(
+                &headers,
+                "Content-Type",
+                "content_type",
+                request_metadata->content_type,
+                error,
+                error_size
             );
-            headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_type_header);
+
+            if (header_result != SUCCESS) {
+                king_object_store_libcurl.curl_slist_free_all_fn(headers);
+                king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+                smart_str_free(&url);
+                return header_result;
+            }
         } else {
             headers = king_object_store_libcurl.curl_slist_append_fn(headers, "Content-Type: application/octet-stream");
         }
     }
     if (request_metadata != NULL && request_metadata->content_encoding[0] != '\0') {
-        char content_encoding_header[128];
-
-        snprintf(
-            content_encoding_header,
-            sizeof(content_encoding_header),
-            "Content-Encoding: %s",
-            request_metadata->content_encoding
+        int header_result = king_object_store_append_named_http_header(
+            &headers,
+            "Content-Encoding",
+            "content_encoding",
+            request_metadata->content_encoding,
+            error,
+            error_size
         );
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, content_encoding_header);
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            smart_str_free(&url);
+            return header_result;
+        }
     }
     if (request_metadata != NULL) {
-        headers = king_object_store_append_metadata_headers(headers, "x-amz-meta-", request_metadata);
+        int header_result = king_object_store_append_metadata_headers(
+            &headers,
+            "x-amz-meta-",
+            request_metadata,
+            error,
+            error_size
+        );
+
+        if (header_result != SUCCESS) {
+            king_object_store_libcurl.curl_slist_free_all_fn(headers);
+            king_object_store_libcurl.curl_easy_cleanup_fn(easy);
+            smart_str_free(&url);
+            return header_result;
+        }
     }
     if (range_header != NULL && range_header[0] != '\0') {
         headers = king_object_store_libcurl.curl_slist_append_fn(headers, range_header);
@@ -879,4 +904,3 @@ static zend_result king_object_store_s3_http_request(
 
     return SUCCESS;
 }
-

--- a/extension/src/object_store/internal/object_store_metadata_headers_and_upload_api.inc
+++ b/extension/src/object_store/internal/object_store_metadata_headers_and_upload_api.inc
@@ -1,77 +1,317 @@
-static struct curl_slist *king_object_store_append_metadata_headers(
-    struct curl_slist *headers,
+int king_object_store_http_header_value_validate(
+    const char *field_name,
+    const char *value,
+    char *error,
+    size_t error_size
+)
+{
+    const unsigned char *cursor = (const unsigned char *) value;
+
+    if (value == NULL || value[0] == '\0') {
+        if (error != NULL && error_size > 0) {
+            error[0] = '\0';
+        }
+        return SUCCESS;
+    }
+
+    while (*cursor != '\0') {
+        if (*cursor == '\r' || *cursor == '\n') {
+            if (error != NULL && error_size > 0) {
+                snprintf(
+                    error,
+                    error_size,
+                    "Object-store metadata field '%s' contains unsupported CR/LF characters for cloud HTTP headers.",
+                    field_name != NULL && field_name[0] != '\0' ? field_name : "value"
+                );
+            }
+            return KING_OBJECT_STORE_RESULT_VALIDATION;
+        }
+        cursor++;
+    }
+
+    if (error != NULL && error_size > 0) {
+        error[0] = '\0';
+    }
+    return SUCCESS;
+}
+
+static int king_object_store_append_named_http_header(
+    struct curl_slist **headers,
+    const char *header_name,
+    const char *field_name,
+    const char *value,
+    char *error,
+    size_t error_size
+)
+{
+    smart_str header = {0};
+    struct curl_slist *updated_headers;
+    int validation_result;
+
+    if (headers == NULL || header_name == NULL || header_name[0] == '\0' || value == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Invalid cloud header append request.");
+        }
+        return FAILURE;
+    }
+
+    validation_result = king_object_store_http_header_value_validate(
+        field_name,
+        value,
+        error,
+        error_size
+    );
+    if (validation_result != SUCCESS) {
+        return validation_result;
+    }
+
+    smart_str_appends(&header, header_name);
+    smart_str_appends(&header, ": ");
+    smart_str_appends(&header, value);
+    smart_str_0(&header);
+
+    updated_headers = king_object_store_libcurl.curl_slist_append_fn(
+        *headers,
+        ZSTR_VAL(header.s)
+    );
+    smart_str_free(&header);
+
+    if (updated_headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
+
+    *headers = updated_headers;
+    return SUCCESS;
+}
+
+static int king_object_store_append_metadata_headers(
+    struct curl_slist **headers,
     const char *prefix,
-    const king_object_metadata_t *metadata
+    const king_object_metadata_t *metadata,
+    char *error,
+    size_t error_size
 )
 {
     char header[512];
 
     if (prefix == NULL || metadata == NULL) {
-        return headers;
+        if (error != NULL && error_size > 0) {
+            error[0] = '\0';
+        }
+        return SUCCESS;
     }
 
-    snprintf(header, sizeof(header), "%sobject-id: %s", prefix, metadata->object_id);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    {
+        smart_str name = {0};
+        int result;
+
+        smart_str_appends(&name, prefix);
+        smart_str_appends(&name, "object-id");
+        smart_str_0(&name);
+        result = king_object_store_append_named_http_header(
+            headers,
+            ZSTR_VAL(name.s),
+            "object_id",
+            metadata->object_id,
+            error,
+            error_size
+        );
+        smart_str_free(&name);
+        if (result != SUCCESS) {
+            return result;
+        }
+    }
 
     snprintf(header, sizeof(header), "%scontent-length: %" PRIu64, prefix, metadata->content_length);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     if (metadata->etag[0] != '\0') {
-        snprintf(header, sizeof(header), "%setag: %s", prefix, metadata->etag);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+        smart_str name = {0};
+        int result;
+
+        smart_str_appends(&name, prefix);
+        smart_str_appends(&name, "etag");
+        smart_str_0(&name);
+        result = king_object_store_append_named_http_header(
+            headers,
+            ZSTR_VAL(name.s),
+            "etag",
+            metadata->etag,
+            error,
+            error_size
+        );
+        smart_str_free(&name);
+        if (result != SUCCESS) {
+            return result;
+        }
     }
     if (metadata->integrity_sha256[0] != '\0') {
-        snprintf(header, sizeof(header), "%sintegrity-sha256: %s", prefix, metadata->integrity_sha256);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+        smart_str name = {0};
+        int result;
+
+        smart_str_appends(&name, prefix);
+        smart_str_appends(&name, "integrity-sha256");
+        smart_str_0(&name);
+        result = king_object_store_append_named_http_header(
+            headers,
+            ZSTR_VAL(name.s),
+            "integrity_sha256",
+            metadata->integrity_sha256,
+            error,
+            error_size
+        );
+        smart_str_free(&name);
+        if (result != SUCCESS) {
+            return result;
+        }
     }
     if (metadata->created_at > 0) {
         snprintf(header, sizeof(header), "%screated-at: %" PRId64, prefix, (int64_t) metadata->created_at);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+        *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+        if (*headers == NULL) {
+            if (error != NULL && error_size > 0) {
+                snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+            }
+            return FAILURE;
+        }
     }
     if (metadata->modified_at > 0) {
         snprintf(header, sizeof(header), "%smodified-at: %" PRId64, prefix, (int64_t) metadata->modified_at);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+        *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+        if (*headers == NULL) {
+            if (error != NULL && error_size > 0) {
+                snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+            }
+            return FAILURE;
+        }
     }
     if (metadata->expires_at > 0) {
         snprintf(header, sizeof(header), "%sexpires-at: %" PRId64, prefix, (int64_t) metadata->expires_at);
-        headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+        *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+        if (*headers == NULL) {
+            if (error != NULL && error_size > 0) {
+                snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+            }
+            return FAILURE;
+        }
     }
 
     snprintf(header, sizeof(header), "%sversion: %" PRIu64, prefix, metadata->version);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%sobject-type: %d", prefix, (int) metadata->object_type);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%scache-policy: %d", prefix, (int) metadata->cache_policy);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%scache-ttl-seconds: %u", prefix, (unsigned) metadata->cache_ttl_seconds);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%slocal-fs-present: %u", prefix, (unsigned) metadata->local_fs_present);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%sdistributed-present: %u", prefix, (unsigned) metadata->distributed_present);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%scloud-s3-present: %u", prefix, (unsigned) metadata->cloud_s3_present);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%scloud-gcs-present: %u", prefix, (unsigned) metadata->cloud_gcs_present);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%scloud-azure-present: %u", prefix, (unsigned) metadata->cloud_azure_present);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%sis-backed-up: %u", prefix, (unsigned) metadata->is_backed_up);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%sreplication-status: %u", prefix, (unsigned) metadata->replication_status);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(header, sizeof(header), "%sis-distributed: %u", prefix, (unsigned) metadata->is_distributed);
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
     snprintf(
         header,
@@ -80,9 +320,18 @@ static struct curl_slist *king_object_store_append_metadata_headers(
         prefix,
         (unsigned) metadata->distribution_peer_count
     );
-    headers = king_object_store_libcurl.curl_slist_append_fn(headers, header);
+    *headers = king_object_store_libcurl.curl_slist_append_fn(*headers, header);
+    if (*headers == NULL) {
+        if (error != NULL && error_size > 0) {
+            snprintf(error, error_size, "Failed to allocate cloud HTTP header storage.");
+        }
+        return FAILURE;
+    }
 
-    return headers;
+    if (error != NULL && error_size > 0) {
+        error[0] = '\0';
+    }
+    return SUCCESS;
 }
 
 int king_object_store_begin_upload_session(
@@ -631,4 +880,3 @@ int king_object_store_get_upload_session_status(
     king_object_store_upload_session_export_status(session, status_out);
     return SUCCESS;
 }
-

--- a/extension/src/object_store/object_store.c
+++ b/extension/src/object_store/object_store.c
@@ -318,10 +318,12 @@ static int king_object_store_require_honest_backend(
     const char *operation_name
 );
 static int king_object_store_local_fs_remove_with_real_backup_semantics(const char *object_id);
-static struct curl_slist *king_object_store_append_metadata_headers(
-    struct curl_slist *headers,
+static int king_object_store_append_metadata_headers(
+    struct curl_slist **headers,
     const char *prefix,
-    const king_object_metadata_t *metadata
+    const king_object_metadata_t *metadata,
+    char *error,
+    size_t error_size
 );
 static void king_object_store_list_entry_from_metadata(
     zval *entry,
@@ -515,6 +517,21 @@ static int king_object_store_azure_append_upload_chunk(
 static int king_object_store_azure_complete_upload_session(
     const char *object_id,
     const HashTable *provider_parts,
+    const king_object_metadata_t *metadata,
+    char *error,
+    size_t error_size
+);
+static int king_object_store_append_named_http_header(
+    struct curl_slist **headers,
+    const char *header_name,
+    const char *field_name,
+    const char *value,
+    char *error,
+    size_t error_size
+);
+static int king_object_store_append_metadata_headers(
+    struct curl_slist **headers,
+    const char *prefix,
     const king_object_metadata_t *metadata,
     char *error,
     size_t error_size

--- a/extension/tests/449-object-store-cloud-metadata-header-sanitization-contract.phpt
+++ b/extension/tests/449-object-store-cloud-metadata-header-sanitization-contract.phpt
@@ -1,0 +1,199 @@
+--TEST--
+King object-store rejects CRLF-bearing cloud metadata header values before network I/O
+--SKIPIF--
+<?php
+if (!function_exists('proc_open') || !function_exists('stream_socket_server')) {
+    echo "skip proc_open and stream_socket_server are required";
+}
+?>
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+require __DIR__ . '/object_store_s3_mock_helper.inc';
+
+function king_object_store_449_cleanup_tree(string $path): void
+{
+    if ($path === '' || !file_exists($path)) {
+        return;
+    }
+
+    if (is_dir($path) && !is_link($path)) {
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            king_object_store_449_cleanup_tree($path . '/' . $entry);
+        }
+
+        @rmdir($path);
+        return;
+    }
+
+    @unlink($path);
+}
+
+function king_object_store_449_backend_config(string $provider, string $endpoint): array
+{
+    return match ($provider) {
+        'cloud_s3' => [
+            'primary_backend' => 'cloud_s3',
+            'cloud_credentials' => [
+                'api_endpoint' => $endpoint,
+                'bucket' => 'header-sanitize-s3',
+                'access_key' => 'access',
+                'secret_key' => 'secret',
+                'region' => 'us-east-1',
+                'path_style' => true,
+                'verify_tls' => false,
+            ],
+        ],
+        'cloud_gcs' => [
+            'primary_backend' => 'cloud_gcs',
+            'cloud_credentials' => [
+                'api_endpoint' => $endpoint,
+                'bucket' => 'header-sanitize-gcs',
+                'access_token' => 'gcs-token',
+                'path_style' => true,
+                'verify_tls' => false,
+            ],
+        ],
+        'cloud_azure' => [
+            'primary_backend' => 'cloud_azure',
+            'cloud_credentials' => [
+                'api_endpoint' => $endpoint,
+                'container' => 'header-sanitize-azure',
+                'access_token' => 'azure-token',
+                'verify_tls' => false,
+            ],
+        ],
+    };
+}
+
+function king_object_store_449_mock_options(string $provider): array
+{
+    return match ($provider) {
+        'cloud_gcs' => [
+            'provider' => 'gcs',
+            'expected_access_token' => 'gcs-token',
+        ],
+        'cloud_azure' => [
+            'provider' => 'azure',
+            'expected_access_token' => 'azure-token',
+        ],
+        default => [],
+    };
+}
+
+function king_object_store_449_event_has_injected_header(array $event): bool
+{
+    foreach ((array) ($event['headers'] ?? []) as $name => $value) {
+        if (str_contains((string) $name, 'X-Evil')) {
+            return true;
+        }
+
+        if (str_contains((string) $value, 'X-Evil')) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+foreach (['cloud_s3', 'cloud_gcs', 'cloud_azure'] as $provider) {
+    $root = sys_get_temp_dir() . '/king_object_store_header_sanitize_449_' . $provider . '_' . getmypid();
+    king_object_store_449_cleanup_tree($root);
+    mkdir($root, 0700, true);
+
+    $mock = king_object_store_s3_mock_start_server(
+        null,
+        '127.0.0.1',
+        king_object_store_449_mock_options($provider)
+    );
+
+    $config = king_object_store_449_backend_config($provider, $mock['endpoint']);
+    $config['storage_root_path'] = $root;
+
+    $typeException = null;
+    $encodingException = null;
+    $uploadException = null;
+
+    var_dump($provider);
+    var_dump(king_object_store_init($config));
+
+    try {
+        king_object_store_put('crlf-type-' . $provider, 'alpha', [
+            'content_type' => "application/json\r\nX-Evil: 1",
+        ]);
+    } catch (Throwable $throwable) {
+        $typeException = $throwable;
+    }
+    var_dump($typeException instanceof King\ValidationException);
+    var_dump($typeException !== null && str_contains($typeException->getMessage(), 'content_type'));
+
+    try {
+        king_object_store_put('crlf-encoding-' . $provider, 'bravo', [
+            'content_encoding' => "gzip\r\nX-Evil: 1",
+        ]);
+    } catch (Throwable $throwable) {
+        $encodingException = $throwable;
+    }
+    var_dump($encodingException instanceof King\ValidationException);
+    var_dump($encodingException !== null && str_contains($encodingException->getMessage(), 'content_encoding'));
+
+    try {
+        king_object_store_begin_resumable_upload('crlf-upload-' . $provider, [
+            'content_type' => "application/octet-stream\r\nX-Evil: 1",
+        ]);
+    } catch (Throwable $throwable) {
+        $uploadException = $throwable;
+    }
+    var_dump($uploadException instanceof King\ValidationException);
+    var_dump($uploadException !== null && str_contains($uploadException->getMessage(), 'content_type'));
+
+    $capture = king_object_store_s3_mock_stop_server($mock);
+    $blockedObjectIds = [
+        'crlf-type-' . $provider,
+        'crlf-encoding-' . $provider,
+        'crlf-upload-' . $provider,
+    ];
+    var_dump(count(array_filter(
+        $capture['events'] ?? [],
+        static fn(array $event): bool =>
+            in_array((string) ($event['object_id'] ?? ''), $blockedObjectIds, true)
+            || king_object_store_449_event_has_injected_header($event)
+    )) === 0);
+
+    king_object_store_449_cleanup_tree($root);
+    king_object_store_s3_mock_cleanup_state_directory($mock['state_directory']);
+}
+?>
+--EXPECT--
+string(8) "cloud_s3"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+string(9) "cloud_gcs"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+string(11) "cloud_azure"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/extension/tests/450-object-store-cloud-imported-metadata-header-sanitization-contract.phpt
+++ b/extension/tests/450-object-store-cloud-imported-metadata-header-sanitization-contract.phpt
@@ -1,0 +1,177 @@
+--TEST--
+King object-store blocks imported cloud metadata with CRLF-bearing header values before emitting write headers
+--SKIPIF--
+<?php
+if (!function_exists('proc_open') || !function_exists('stream_socket_server')) {
+    echo "skip proc_open and stream_socket_server are required";
+}
+?>
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+require __DIR__ . '/object_store_s3_mock_helper.inc';
+
+function king_object_store_450_cleanup_tree(string $path): void
+{
+    if ($path === '' || !file_exists($path)) {
+        return;
+    }
+
+    if (is_dir($path) && !is_link($path)) {
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            king_object_store_450_cleanup_tree($path . '/' . $entry);
+        }
+
+        @rmdir($path);
+        return;
+    }
+
+    @unlink($path);
+}
+
+function king_object_store_450_backend_config(string $provider, string $endpoint): array
+{
+    return match ($provider) {
+        'cloud_s3' => [
+            'primary_backend' => 'cloud_s3',
+            'cloud_credentials' => [
+                'api_endpoint' => $endpoint,
+                'bucket' => 'import-sanitize-s3',
+                'access_key' => 'access',
+                'secret_key' => 'secret',
+                'region' => 'us-east-1',
+                'path_style' => true,
+                'verify_tls' => false,
+            ],
+        ],
+        'cloud_gcs' => [
+            'primary_backend' => 'cloud_gcs',
+            'cloud_credentials' => [
+                'api_endpoint' => $endpoint,
+                'bucket' => 'import-sanitize-gcs',
+                'access_token' => 'gcs-token',
+                'path_style' => true,
+                'verify_tls' => false,
+            ],
+        ],
+        'cloud_azure' => [
+            'primary_backend' => 'cloud_azure',
+            'cloud_credentials' => [
+                'api_endpoint' => $endpoint,
+                'container' => 'import-sanitize-azure',
+                'access_token' => 'azure-token',
+                'verify_tls' => false,
+            ],
+        ],
+    };
+}
+
+function king_object_store_450_mock_options(string $provider): array
+{
+    return match ($provider) {
+        'cloud_gcs' => [
+            'provider' => 'gcs',
+            'expected_access_token' => 'gcs-token',
+        ],
+        'cloud_azure' => [
+            'provider' => 'azure',
+            'expected_access_token' => 'azure-token',
+        ],
+        default => [],
+    };
+}
+
+function king_object_store_450_write_import_fixture(string $directory, string $objectId, string $payload): void
+{
+    $sha256 = hash('sha256', $payload);
+    file_put_contents($directory . '/' . $objectId, $payload);
+    file_put_contents(
+        $directory . '/' . $objectId . '.meta',
+        "object_id={$objectId}\n"
+        . "content_type=application/x-king-restore\r\n"
+        . "x-ignore=1\n"
+        . "content_encoding=\n"
+        . "etag={$sha256}\n"
+        . "integrity_sha256={$sha256}\n"
+        . "content_length=" . strlen($payload) . "\n"
+        . "version=1\n"
+        . "created_at=1700000000\n"
+        . "modified_at=1700000000\n"
+        . "expires_at=0\n"
+        . "object_type=1\n"
+        . "cache_policy=0\n"
+        . "cache_ttl_seconds=0\n"
+        . "local_fs_present=1\n"
+        . "distributed_present=0\n"
+        . "cloud_s3_present=0\n"
+        . "cloud_gcs_present=0\n"
+        . "cloud_azure_present=0\n"
+        . "is_backed_up=0\n"
+        . "replication_status=0\n"
+        . "is_distributed=0\n"
+        . "distribution_peer_count=0\n"
+    );
+}
+
+foreach (['cloud_s3', 'cloud_gcs', 'cloud_azure'] as $provider) {
+    $root = sys_get_temp_dir() . '/king_object_store_header_sanitize_450_' . $provider . '_' . getmypid();
+    $import = $root . '/import';
+    $objectId = 'restore-' . $provider;
+
+    king_object_store_450_cleanup_tree($root);
+    mkdir($import, 0700, true);
+    king_object_store_450_write_import_fixture($import, $objectId, 'payload');
+
+    $mock = king_object_store_s3_mock_start_server(
+        null,
+        '127.0.0.1',
+        king_object_store_450_mock_options($provider)
+    );
+
+    $config = king_object_store_450_backend_config($provider, $mock['endpoint']);
+    $config['storage_root_path'] = $root;
+
+    var_dump($provider);
+    var_dump(king_object_store_init($config));
+    var_dump(king_object_store_restore_object($objectId, $import));
+
+    $stats = king_object_store_get_stats()['object_store'];
+    var_dump(str_contains($stats['runtime_primary_adapter_error'], 'CR/LF'));
+    var_dump(king_object_store_get($objectId));
+
+    $capture = king_object_store_s3_mock_stop_server($mock);
+    var_dump(count(array_filter(
+        $capture['events'] ?? [],
+        static fn(array $event): bool =>
+            ($event['method'] ?? '') === 'PUT'
+            && ($event['object_id'] ?? '') === $objectId
+    )) === 0);
+
+    king_object_store_450_cleanup_tree($root);
+    king_object_store_s3_mock_cleanup_state_directory($mock['state_directory']);
+}
+?>
+--EXPECT--
+string(8) "cloud_s3"
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+string(9) "cloud_gcs"
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+string(11) "cloud_azure"
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)


### PR DESCRIPTION
Title:
Harden cloud object-store metadata headers

Description:
This PR fixes CRLF/header-injection risk in object-store cloud metadata emission.

Included:
- shared validation for cloud-emitted metadata/content header values
- rejection of unsafe `content_type` and `content_encoding` values before remote request emission
- cloud adapter updates so metadata headers are only emitted through the checked helper
- regression coverage for direct and imported metadata/header sanitization paths

Impact:
- prevents header injection in real cloud object-store request construction
- keeps metadata handling explicit and safe across S3, GCS, and Azure paths
