### PR TITLE
Security/object store metadata cache bounds

### DIFF
--- a/documentation/object-store-and-cdn.md
+++ b/documentation/object-store-and-cdn.md
@@ -812,7 +812,9 @@ The third family is topology and metadata. Keys such as
 `storage.metadata_agent_uri`, `storage.node_discovery_mode`,
 `storage.node_static_list`, `storage.metadata_cache_enable`, and
 `storage.metadata_cache_ttl_sec` decide where metadata authority lives and how
-the store learns about storage topology.
+the store learns about storage topology. `storage.metadata_cache_max_entries`
+adds the memory-safety boundary for long-lived runtimes so metadata readahead
+and ordinary object churn do not grow the process-local cache without bound.
 
 The fourth family is fast-path preparation. `storage.enable_directstorage` is
 the main switch for predictive residency and direct read paths for likely future

--- a/documentation/runtime-configuration.md
+++ b/documentation/runtime-configuration.md
@@ -340,6 +340,7 @@ core part of the application.
 | `storage.node_static_list` | Provides the static storage-node list. |
 | `storage.metadata_cache_enable` | Enables or disables metadata caching. |
 | `storage.metadata_cache_ttl_sec` | Sets metadata cache TTL. |
+| `storage.metadata_cache_max_entries` | Caps how many metadata entries the runtime keeps in its process-local cache before evicting older entries. |
 | `storage.enable_directstorage` | Enables or disables DirectStorage integration. |
 
 ## CDN: `cdn.*`

--- a/documentation/system-ini-reference.md
+++ b/documentation/system-ini-reference.md
@@ -353,6 +353,7 @@ they belong in `php.ini`.
 | `king.storage_node_static_list` | `127.0.0.1:9711,127.0.0.1:9712` | Lists storage nodes when static discovery is used. |
 | `king.storage_metadata_cache_enable` | `1` | Enables metadata caching. |
 | `king.storage_metadata_cache_ttl_sec` | `60` | Sets the metadata cache lifetime in seconds. |
+| `king.storage_metadata_cache_max_entries` | `4096` | Caps the process-local metadata cache so long-lived runtimes evict older entries instead of growing without bound. |
 | `king.storage_enable_directstorage` | `0` | Enables direct storage paths for storage-heavy compute workloads. |
 | `king.cdn_enable` | `0` | Enables the native CDN subsystem. |
 | `king.cdn_cache_mode` | `disk` | Selects the cache storage mode. |

--- a/extension/include/config/native_object_store/base_layer.h
+++ b/extension/include/config/native_object_store/base_layer.h
@@ -38,6 +38,7 @@ typedef struct _kg_native_object_store_config_t {
     /* --- Performance & Caching --- */
     bool metadata_cache_enable;
     zend_long metadata_cache_ttl_sec;
+    zend_long metadata_cache_max_entries;
     bool enable_directstorage;
 
 } kg_native_object_store_config_t;

--- a/extension/include/object_store/object_store_internal.h
+++ b/extension/include/object_store/object_store_internal.h
@@ -114,6 +114,10 @@ int king_object_store_meta_write(const char *object_id, const king_object_metada
 int king_object_store_meta_read(const char *object_id, king_object_metadata_t *metadata);
 void king_object_store_meta_remove(const char *object_id);
 int king_object_store_runtime_metadata_cache_read(const char *object_id, king_object_metadata_t *metadata);
+void king_object_store_runtime_metadata_cache_collect_stats(
+    zend_long *entry_count,
+    zend_long *eviction_count
+);
 
 /* Rehydrate runtime stats from disk on init */
 void king_object_store_rehydrate_stats(void);

--- a/extension/src/config/native_object_store/config.c
+++ b/extension/src/config/native_object_store/config.c
@@ -93,6 +93,10 @@ int kg_config_native_object_store_apply_userland_config_to(
             if (kg_validate_positive_long(value, &target->metadata_cache_ttl_sec) != SUCCESS) {
                 return FAILURE;
             }
+        } else if (zend_string_equals_literal(key, "metadata_cache_max_entries")) {
+            if (kg_validate_positive_long(value, &target->metadata_cache_max_entries) != SUCCESS) {
+                return FAILURE;
+            }
         } else if (zend_string_equals_literal(key, "enable_directstorage")) {
             if (kg_validate_bool(value, "enable_directstorage") != SUCCESS) {
                 return FAILURE;

--- a/extension/src/config/native_object_store/default.c
+++ b/extension/src/config/native_object_store/default.c
@@ -20,5 +20,6 @@ void kg_config_native_object_store_defaults_load(void)
 
     king_native_object_store_config.metadata_cache_enable = true;
     king_native_object_store_config.metadata_cache_ttl_sec = 60;
+    king_native_object_store_config.metadata_cache_max_entries = 4096;
     king_native_object_store_config.enable_directstorage = false;
 }

--- a/extension/src/config/native_object_store/ini.c
+++ b/extension/src/config/native_object_store/ini.c
@@ -34,6 +34,8 @@ static ZEND_INI_MH(OnUpdateObjectStorePositiveLong)
         king_native_object_store_config.default_chunk_size_mb = val;
     } else if (zend_string_equals_literal(entry->name, "king.storage_metadata_cache_ttl_sec")) {
         king_native_object_store_config.metadata_cache_ttl_sec = val;
+    } else if (zend_string_equals_literal(entry->name, "king.storage_metadata_cache_max_entries")) {
+        king_native_object_store_config.metadata_cache_max_entries = val;
     }
 
     return SUCCESS;
@@ -116,6 +118,7 @@ PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY("king.storage_node_static_list", "127.0.0.1:9711,127.0.0.1:9712", PHP_INI_SYSTEM, OnUpdateString, node_static_list, kg_native_object_store_config_t, king_native_object_store_config)
     STD_PHP_INI_ENTRY("king.storage_metadata_cache_enable", "1", PHP_INI_SYSTEM, OnUpdateBool, metadata_cache_enable, kg_native_object_store_config_t, king_native_object_store_config)
     ZEND_INI_ENTRY("king.storage_metadata_cache_ttl_sec", "60", PHP_INI_SYSTEM, OnUpdateObjectStorePositiveLong)
+    ZEND_INI_ENTRY("king.storage_metadata_cache_max_entries", "4096", PHP_INI_SYSTEM, OnUpdateObjectStorePositiveLong)
     STD_PHP_INI_ENTRY("king.storage_enable_directstorage", "0", PHP_INI_SYSTEM, OnUpdateBool, enable_directstorage, kg_native_object_store_config_t, king_native_object_store_config)
 PHP_INI_END()
 

--- a/extension/src/core/introspection/object_store/stats.inc
+++ b/extension/src/core/introspection/object_store/stats.inc
@@ -7,11 +7,17 @@ PHP_FUNCTION(king_object_store_get_stats)
     zend_long cached_object_count = 0;
     zend_long cached_bytes = 0;
     zend_long latest_cached_at = 0;
+    zend_long runtime_metadata_cache_entries = 0;
+    zend_long runtime_metadata_cache_eviction_count = 0;
 
     ZEND_PARSE_PARAMETERS_NONE();
 
     array_init(return_value);
     king_cdn_collect_live_stats(&cached_object_count, &cached_bytes, &latest_cached_at);
+    king_object_store_runtime_metadata_cache_collect_stats(
+        &runtime_metadata_cache_entries,
+        &runtime_metadata_cache_eviction_count
+    );
 
     array_init(&object_store);
     add_assoc_bool(&object_store, "enabled", king_native_object_store_config.enable ? 1 : 0);
@@ -22,6 +28,7 @@ PHP_FUNCTION(king_object_store_get_stats)
     add_assoc_string(&object_store, "node_discovery_mode", king_safe_string(king_native_object_store_config.node_discovery_mode));
     add_assoc_bool(&object_store, "metadata_cache_enabled", king_native_object_store_config.metadata_cache_enable ? 1 : 0);
     add_assoc_long(&object_store, "metadata_cache_ttl_sec", king_native_object_store_config.metadata_cache_ttl_sec);
+    add_assoc_long(&object_store, "metadata_cache_max_entries", king_native_object_store_config.metadata_cache_max_entries);
     add_assoc_bool(&object_store, "directstorage_enabled", king_native_object_store_config.enable_directstorage ? 1 : 0);
 
     /* Use native runtime variables directly from the new C core */
@@ -110,6 +117,8 @@ PHP_FUNCTION(king_object_store_get_stats)
     add_assoc_string(&object_store, "runtime_primary_adapter_error", king_object_store_runtime.primary_adapter_error[0] == '\0' ? "" : king_object_store_runtime.primary_adapter_error);
     add_assoc_string(&object_store, "runtime_backup_adapter_status", king_object_store_runtime.backup_adapter_status[0] == '\0' ? "unknown" : king_object_store_runtime.backup_adapter_status);
     add_assoc_string(&object_store, "runtime_backup_adapter_error", king_object_store_runtime.backup_adapter_error[0] == '\0' ? "" : king_object_store_runtime.backup_adapter_error);
+    add_assoc_long(&object_store, "runtime_metadata_cache_entries", runtime_metadata_cache_entries);
+    add_assoc_long(&object_store, "runtime_metadata_cache_eviction_count", runtime_metadata_cache_eviction_count);
     add_assoc_long(&object_store, "object_count", king_object_store_runtime.current_object_count);
     add_assoc_long(&object_store, "stored_bytes", king_object_store_runtime.current_stored_bytes);
     

--- a/extension/src/core/introspection/system.inc
+++ b/extension/src/core/introspection/system.inc
@@ -177,6 +177,12 @@ PHP_FUNCTION(king_system_get_component_info)
             king_native_object_store_config.default_replication_factor);
         add_assoc_long(&configuration, "chunk_size_mb",
             king_native_object_store_config.default_chunk_size_mb);
+        add_assoc_bool(&configuration, "metadata_cache_enabled",
+            king_native_object_store_config.metadata_cache_enable ? 1 : 0);
+        add_assoc_long(&configuration, "metadata_cache_ttl_sec",
+            king_native_object_store_config.metadata_cache_ttl_sec);
+        add_assoc_long(&configuration, "metadata_cache_max_entries",
+            king_native_object_store_config.metadata_cache_max_entries);
     } else if (zend_string_equals_literal(component_name, "cdn")) {
         king_component_info_init(return_value, "cdn", "config_backed");
         array_init(&configuration);

--- a/extension/src/object_store/internal/object_store_lifecycle.inc
+++ b/extension/src/object_store/internal/object_store_lifecycle.inc
@@ -109,7 +109,8 @@ int king_object_store_init_system(king_object_store_config_t *config)
         struct dirent *ent;
         char meta_path[1024];
 
-        if (king_object_store_runtime_metadata_cache_ensure() == SUCCESS) {
+        if (king_native_object_store_config.metadata_cache_enable
+            && king_object_store_runtime_metadata_cache_ensure() == SUCCESS) {
             dir = opendir(king_object_store_runtime.config.storage_root_path);
             if (dir != NULL) {
                 while ((ent = readdir(dir)) != NULL) {

--- a/extension/src/object_store/internal/object_store_runtime_state.inc
+++ b/extension/src/object_store/internal/object_store_runtime_state.inc
@@ -14,24 +14,197 @@ static zend_bool king_object_store_verify_integrity_buffer(
     return strcmp(computed, metadata->integrity_sha256) == 0;
 }
 
-static void king_object_store_runtime_metadata_cache_entry_free(king_object_metadata_t *metadata)
+typedef struct _king_object_store_runtime_metadata_cache_entry_t {
+    king_object_metadata_t metadata;
+    time_t cached_at;
+    uint64_t last_access_sequence;
+} king_object_store_runtime_metadata_cache_entry_t;
+
+static uint64_t king_object_store_runtime_metadata_cache_sequence = 0;
+static uint64_t king_object_store_runtime_metadata_cache_eviction_count = 0;
+
+static zend_bool king_object_store_runtime_metadata_cache_enabled(void)
 {
-    if (metadata == NULL) {
+    return king_native_object_store_config.metadata_cache_enable ? 1 : 0;
+}
+
+static zend_long king_object_store_runtime_metadata_cache_ttl_sec(void)
+{
+    if (king_native_object_store_config.metadata_cache_ttl_sec <= 0) {
+        return 1;
+    }
+
+    return king_native_object_store_config.metadata_cache_ttl_sec;
+}
+
+static zend_long king_object_store_runtime_metadata_cache_max_entries(void)
+{
+    if (king_native_object_store_config.metadata_cache_max_entries <= 0) {
+        return 1;
+    }
+
+    return king_native_object_store_config.metadata_cache_max_entries;
+}
+
+static uint64_t king_object_store_runtime_metadata_cache_next_sequence(void)
+{
+    king_object_store_runtime_metadata_cache_sequence++;
+    if (king_object_store_runtime_metadata_cache_sequence == 0) {
+        king_object_store_runtime_metadata_cache_sequence = 1;
+    }
+
+    return king_object_store_runtime_metadata_cache_sequence;
+}
+
+static void king_object_store_runtime_metadata_cache_note_eviction(void)
+{
+    if (king_object_store_runtime_metadata_cache_eviction_count < UINT64_MAX) {
+        king_object_store_runtime_metadata_cache_eviction_count++;
+    }
+}
+
+static zend_bool king_object_store_runtime_metadata_cache_entry_is_expired(
+    const king_object_store_runtime_metadata_cache_entry_t *entry,
+    time_t now
+)
+{
+    zend_long ttl_sec;
+
+    if (entry == NULL || entry->cached_at <= 0) {
+        return 1;
+    }
+
+    ttl_sec = king_object_store_runtime_metadata_cache_ttl_sec();
+    if (ttl_sec <= 0) {
+        return 0;
+    }
+
+    if (now < entry->cached_at) {
+        return 0;
+    }
+
+    return (zend_long) (now - entry->cached_at) >= ttl_sec;
+}
+
+static void king_object_store_runtime_metadata_cache_entry_free(
+    king_object_store_runtime_metadata_cache_entry_t *entry
+)
+{
+    if (entry == NULL) {
         return;
     }
 
-    pefree(metadata, 1);
+    pefree(entry, 1);
 }
 
 static void king_object_store_runtime_metadata_cache_zval_dtor(zval *zv)
 {
     if (Z_TYPE_P(zv) == IS_PTR) {
-        king_object_store_runtime_metadata_cache_entry_free((king_object_metadata_t *) Z_PTR_P(zv));
+        king_object_store_runtime_metadata_cache_entry_free(
+            (king_object_store_runtime_metadata_cache_entry_t *) Z_PTR_P(zv)
+        );
     }
+}
+
+static zend_bool king_object_store_runtime_metadata_cache_remove_expired_once(time_t now)
+{
+    zend_string *expired_key = NULL;
+    zend_string *key;
+    zval *stored_entry;
+
+    if (!king_object_store_runtime_metadata_cache_initialized) {
+        return 0;
+    }
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(&king_object_store_runtime_metadata_cache, key, stored_entry) {
+        king_object_store_runtime_metadata_cache_entry_t *entry;
+
+        if (key == NULL || Z_TYPE_P(stored_entry) != IS_PTR || Z_PTR_P(stored_entry) == NULL) {
+            continue;
+        }
+
+        entry = (king_object_store_runtime_metadata_cache_entry_t *) Z_PTR_P(stored_entry);
+        if (!king_object_store_runtime_metadata_cache_entry_is_expired(entry, now)) {
+            continue;
+        }
+
+        expired_key = zend_string_copy(key);
+        break;
+    } ZEND_HASH_FOREACH_END();
+
+    if (expired_key == NULL) {
+        return 0;
+    }
+
+    zend_hash_del(&king_object_store_runtime_metadata_cache, expired_key);
+    zend_string_release(expired_key);
+    king_object_store_runtime_metadata_cache_note_eviction();
+    return 1;
+}
+
+static void king_object_store_runtime_metadata_cache_prune_expired(void)
+{
+    time_t now;
+
+    if (!king_object_store_runtime_metadata_cache_initialized) {
+        return;
+    }
+
+    now = time(NULL);
+    while (king_object_store_runtime_metadata_cache_remove_expired_once(now)) {
+    }
+}
+
+static int king_object_store_runtime_metadata_cache_evict_oldest(void)
+{
+    zend_string *oldest_key = NULL;
+    zend_string *key;
+    zval *stored_entry;
+    uint64_t oldest_sequence = UINT64_MAX;
+    time_t oldest_cached_at = 0;
+
+    if (!king_object_store_runtime_metadata_cache_initialized
+        || zend_hash_num_elements(&king_object_store_runtime_metadata_cache) == 0) {
+        return FAILURE;
+    }
+
+    ZEND_HASH_FOREACH_STR_KEY_VAL(&king_object_store_runtime_metadata_cache, key, stored_entry) {
+        king_object_store_runtime_metadata_cache_entry_t *entry;
+
+        if (key == NULL || Z_TYPE_P(stored_entry) != IS_PTR || Z_PTR_P(stored_entry) == NULL) {
+            continue;
+        }
+
+        entry = (king_object_store_runtime_metadata_cache_entry_t *) Z_PTR_P(stored_entry);
+        if (oldest_key == NULL
+            || entry->last_access_sequence < oldest_sequence
+            || (entry->last_access_sequence == oldest_sequence
+                && entry->cached_at < oldest_cached_at)) {
+            if (oldest_key != NULL) {
+                zend_string_release(oldest_key);
+            }
+            oldest_key = zend_string_copy(key);
+            oldest_sequence = entry->last_access_sequence;
+            oldest_cached_at = entry->cached_at;
+        }
+    } ZEND_HASH_FOREACH_END();
+
+    if (oldest_key == NULL) {
+        return FAILURE;
+    }
+
+    zend_hash_del(&king_object_store_runtime_metadata_cache, oldest_key);
+    zend_string_release(oldest_key);
+    king_object_store_runtime_metadata_cache_note_eviction();
+    return SUCCESS;
 }
 
 static int king_object_store_runtime_metadata_cache_ensure(void)
 {
+    if (!king_object_store_runtime_metadata_cache_enabled()) {
+        return SUCCESS;
+    }
+
     if (king_object_store_runtime_metadata_cache_initialized) {
         return SUCCESS;
     }
@@ -49,21 +222,23 @@ static int king_object_store_runtime_metadata_cache_ensure(void)
 
 static void king_object_store_runtime_metadata_cache_reset(void)
 {
-    if (!king_object_store_runtime_metadata_cache_initialized) {
-        return;
+    if (king_object_store_runtime_metadata_cache_initialized) {
+        zend_hash_destroy(&king_object_store_runtime_metadata_cache);
+        king_object_store_runtime_metadata_cache_initialized = false;
     }
 
-    zend_hash_destroy(&king_object_store_runtime_metadata_cache);
-    king_object_store_runtime_metadata_cache_initialized = false;
+    king_object_store_runtime_metadata_cache_sequence = 0;
+    king_object_store_runtime_metadata_cache_eviction_count = 0;
 }
 
 static void king_object_store_runtime_metadata_cache_clear(void)
 {
-    if (!king_object_store_runtime_metadata_cache_initialized) {
-        return;
+    if (king_object_store_runtime_metadata_cache_initialized) {
+        zend_hash_clean(&king_object_store_runtime_metadata_cache);
     }
 
-    zend_hash_clean(&king_object_store_runtime_metadata_cache);
+    king_object_store_runtime_metadata_cache_sequence = 0;
+    king_object_store_runtime_metadata_cache_eviction_count = 0;
 }
 
 static int king_object_store_runtime_metadata_cache_store(
@@ -72,22 +247,46 @@ static int king_object_store_runtime_metadata_cache_store(
 )
 {
     zend_string *persistent_key;
-    king_object_metadata_t *copy;
+    king_object_store_runtime_metadata_cache_entry_t *copy;
     zval stored_metadata;
+    zend_bool has_existing_entry;
+    zend_long max_entries;
 
     if (object_id == NULL || object_id[0] == '\0' || metadata == NULL) {
         return FAILURE;
+    }
+
+    if (!king_object_store_runtime_metadata_cache_enabled()) {
+        return SUCCESS;
     }
 
     if (king_object_store_runtime_metadata_cache_ensure() != SUCCESS) {
         return FAILURE;
     }
 
+    king_object_store_runtime_metadata_cache_prune_expired();
+    has_existing_entry = zend_hash_str_exists(
+        &king_object_store_runtime_metadata_cache,
+        object_id,
+        strlen(object_id)
+    );
+    max_entries = king_object_store_runtime_metadata_cache_max_entries();
+
+    while (!has_existing_entry
+        && zend_hash_num_elements(&king_object_store_runtime_metadata_cache) >= (uint32_t) max_entries) {
+        if (king_object_store_runtime_metadata_cache_evict_oldest() != SUCCESS) {
+            return FAILURE;
+        }
+    }
+
     copy = pemalloc(sizeof(*copy), 1);
     if (copy == NULL) {
         return FAILURE;
     }
-    *copy = *metadata;
+    memset(copy, 0, sizeof(*copy));
+    copy->metadata = *metadata;
+    copy->cached_at = time(NULL);
+    copy->last_access_sequence = king_object_store_runtime_metadata_cache_next_sequence();
 
     ZVAL_PTR(&stored_metadata, copy);
     persistent_key = zend_string_init(object_id, strlen(object_id), 1);
@@ -97,17 +296,24 @@ static int king_object_store_runtime_metadata_cache_store(
     return SUCCESS;
 }
 
+static void king_object_store_runtime_metadata_cache_remove(const char *object_id);
+
 int king_object_store_runtime_metadata_cache_read(
     const char *object_id,
     king_object_metadata_t *metadata
 )
 {
     zval *cached_entry;
+    king_object_store_runtime_metadata_cache_entry_t *entry;
 
-    if (object_id == NULL || metadata == NULL || !king_object_store_runtime_metadata_cache_initialized) {
+    if (object_id == NULL
+        || metadata == NULL
+        || !king_object_store_runtime_metadata_cache_initialized
+        || !king_object_store_runtime_metadata_cache_enabled()) {
         return FAILURE;
     }
 
+    king_object_store_runtime_metadata_cache_prune_expired();
     cached_entry = zend_hash_str_find(
         &king_object_store_runtime_metadata_cache,
         object_id,
@@ -117,7 +323,15 @@ int king_object_store_runtime_metadata_cache_read(
         return FAILURE;
     }
 
-    *metadata = *((king_object_metadata_t *) Z_PTR_P(cached_entry));
+    entry = (king_object_store_runtime_metadata_cache_entry_t *) Z_PTR_P(cached_entry);
+    if (king_object_store_runtime_metadata_cache_entry_is_expired(entry, time(NULL))) {
+        king_object_store_runtime_metadata_cache_remove(object_id);
+        king_object_store_runtime_metadata_cache_note_eviction();
+        return FAILURE;
+    }
+
+    entry->last_access_sequence = king_object_store_runtime_metadata_cache_next_sequence();
+    *metadata = entry->metadata;
     return SUCCESS;
 }
 
@@ -132,6 +346,24 @@ static void king_object_store_runtime_metadata_cache_remove(const char *object_i
         object_id,
         strlen(object_id)
     );
+}
+
+void king_object_store_runtime_metadata_cache_collect_stats(
+    zend_long *entry_count,
+    zend_long *eviction_count
+)
+{
+    king_object_store_runtime_metadata_cache_prune_expired();
+
+    if (entry_count != NULL) {
+        *entry_count = king_object_store_runtime_metadata_cache_initialized
+            ? (zend_long) zend_hash_num_elements(&king_object_store_runtime_metadata_cache)
+            : 0;
+    }
+
+    if (eviction_count != NULL) {
+        *eviction_count = (zend_long) king_object_store_runtime_metadata_cache_eviction_count;
+    }
 }
 
 static zend_result king_object_store_fill_random_bytes(uint8_t *target, size_t target_len)
@@ -935,4 +1167,3 @@ static void king_object_store_release_read_buffer(void **data, size_t *data_size
         *data_size = 0;
     }
 }
-

--- a/extension/src/object_store/object_store.c
+++ b/extension/src/object_store/object_store.c
@@ -12,6 +12,7 @@
 
 #include "php_king.h"
 #include "object_store/object_store_internal.h"
+#include "include/config/native_object_store/base_layer.h"
 #include "Zend/zend_smart_str.h"
 #include "main/php_streams.h"
 #include "ext/standard/base64.h"

--- a/extension/tests/009-status-surfaces.phpt
+++ b/extension/tests/009-status-surfaces.phpt
@@ -18,7 +18,10 @@ var_dump($storage['object_store']['metadata_agent_uri']);
 var_dump($storage['object_store']['node_discovery_mode']);
 var_dump($storage['object_store']['metadata_cache_enabled']);
 var_dump($storage['object_store']['metadata_cache_ttl_sec']);
+var_dump($storage['object_store']['metadata_cache_max_entries']);
 var_dump($storage['object_store']['directstorage_enabled']);
+var_dump($storage['object_store']['runtime_metadata_cache_entries']);
+var_dump($storage['object_store']['runtime_metadata_cache_eviction_count']);
 var_dump($storage['object_store']['object_count']);
 var_dump($storage['object_store']['stored_bytes']);
 var_dump($storage['object_store']['latest_object_at']);
@@ -79,7 +82,10 @@ string(14) "127.0.0.1:9701"
 string(6) "static"
 bool(true)
 int(60)
+int(4096)
 bool(false)
+int(0)
+int(0)
 int(0)
 int(0)
 NULL

--- a/extension/tests/030-system-component-info-config-backed-matrix.phpt
+++ b/extension/tests/030-system-component-info-config-backed-matrix.phpt
@@ -123,7 +123,7 @@ array(6) {
 }
 string(12) "object_store"
 string(13) "config_backed"
-array(7) {
+array(10) {
   [0]=>
   string(7) "enabled"
   [1]=>
@@ -138,6 +138,12 @@ array(7) {
   string(18) "replication_factor"
   [6]=>
   string(13) "chunk_size_mb"
+  [7]=>
+  string(22) "metadata_cache_enabled"
+  [8]=>
+  string(22) "metadata_cache_ttl_sec"
+  [9]=>
+  string(26) "metadata_cache_max_entries"
 }
 bool(true)
 array(6) {

--- a/extension/tests/451-object-store-metadata-cache-bounds-contract.phpt
+++ b/extension/tests/451-object-store-metadata-cache-bounds-contract.phpt
@@ -1,0 +1,55 @@
+--TEST--
+King object-store metadata cache stays bounded under many unique object ids
+--INI--
+king.security_allow_config_override=1
+king.storage_metadata_cache_max_entries=4
+--FILE--
+<?php
+$dir = sys_get_temp_dir() . '/king_object_store_meta_cache_451_' . getmypid();
+if (!is_dir($dir)) {
+    mkdir($dir, 0700, true);
+}
+
+$allOkay = king_object_store_init([
+    'storage_root_path' => $dir,
+    'primary_backend' => 'local_fs',
+    'max_storage_size_bytes' => 1024 * 1024,
+]);
+
+for ($i = 0; $i < 10; $i++) {
+    $allOkay = $allOkay && king_object_store_put('cache-bound-' . $i, 'payload-' . $i);
+}
+
+var_dump($allOkay);
+
+$stats = king_object_store_get_stats()['object_store'];
+var_dump($stats['metadata_cache_max_entries']);
+var_dump($stats['runtime_metadata_cache_entries'] <= 4);
+var_dump($stats['runtime_metadata_cache_eviction_count'] >= 6);
+
+$meta = king_object_store_get_metadata('cache-bound-0');
+var_dump(is_array($meta));
+var_dump($meta['object_id']);
+var_dump($meta['content_length']);
+
+$stats = king_object_store_get_stats()['object_store'];
+var_dump($stats['runtime_metadata_cache_entries'] <= 4);
+var_dump($stats['runtime_metadata_cache_eviction_count'] >= 6);
+
+foreach (scandir($dir) as $entry) {
+    if ($entry !== '.' && $entry !== '..') {
+        @unlink($dir . '/' . $entry);
+    }
+}
+@rmdir($dir);
+?>
+--EXPECT--
+bool(true)
+int(4)
+bool(true)
+bool(true)
+bool(true)
+string(13) "cache-bound-0"
+int(9)
+bool(true)
+bool(true)

--- a/extension/tests/452-object-store-metadata-cache-ttl-contract.phpt
+++ b/extension/tests/452-object-store-metadata-cache-ttl-contract.phpt
@@ -1,0 +1,55 @@
+--TEST--
+King object-store metadata cache evicts expired entries and rehydrates from durable metadata
+--INI--
+king.security_allow_config_override=1
+king.storage_metadata_cache_max_entries=16
+king.storage_metadata_cache_ttl_sec=1
+--FILE--
+<?php
+$dir = sys_get_temp_dir() . '/king_object_store_meta_cache_452_' . getmypid();
+if (!is_dir($dir)) {
+    mkdir($dir, 0700, true);
+}
+
+var_dump(king_object_store_init([
+    'storage_root_path' => $dir,
+    'primary_backend' => 'local_fs',
+    'max_storage_size_bytes' => 1024 * 1024,
+]));
+
+var_dump(king_object_store_put('ttl-doc', 'payload'));
+
+$stats = king_object_store_get_stats()['object_store'];
+var_dump($stats['runtime_metadata_cache_entries']);
+
+sleep(2);
+
+$stats = king_object_store_get_stats()['object_store'];
+var_dump($stats['runtime_metadata_cache_entries']);
+var_dump($stats['runtime_metadata_cache_eviction_count'] >= 1);
+
+$meta = king_object_store_get_metadata('ttl-doc');
+var_dump(is_array($meta));
+var_dump($meta['object_id']);
+
+$stats = king_object_store_get_stats()['object_store'];
+var_dump($stats['runtime_metadata_cache_entries']);
+var_dump($stats['runtime_metadata_cache_eviction_count'] >= 1);
+
+foreach (scandir($dir) as $entry) {
+    if ($entry !== '.' && $entry !== '..') {
+        @unlink($dir . '/' . $entry);
+    }
+}
+@rmdir($dir);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+int(1)
+int(0)
+bool(true)
+bool(true)
+string(7) "ttl-doc"
+int(1)
+bool(true)

--- a/stubs/king.php
+++ b/stubs/king.php
@@ -1061,6 +1061,7 @@ namespace {
      *     node_discovery_mode:string,
      *     metadata_cache_enabled:bool,
      *     metadata_cache_ttl_sec:int,
+     *     metadata_cache_max_entries:int,
      *     directstorage_enabled:bool,
      *     local_registry_initialized:bool,
      *     runtime_initialized:bool,
@@ -1073,6 +1074,8 @@ namespace {
      *     runtime_capacity_available_bytes:int|null,
      *     runtime_replication_factor:int,
      *     runtime_chunk_size_kb:int,
+     *     runtime_metadata_cache_entries:int,
+     *     runtime_metadata_cache_eviction_count:int,
      *     object_count:int,
      *     stored_bytes:int,
      *     latest_object_at:int|null


### PR DESCRIPTION
Title:
Bound object-store metadata cache growth

Description:
This PR hardens the object-store runtime against memory-growth DoS caused by an unbounded process-local metadata cache.

Included:
- a hard cap for runtime metadata-cache entries
- actual TTL-based eviction instead of unbounded accumulation
- on-demand metadata reload after eviction from sidecar metadata
- runtime/system status surfaces for cache size, cap, and eviction count
- regression coverage for both entry-cap and TTL behavior

Impact:
- prevents unbounded memory growth in long-lived runtimes
- keeps the metadata cache useful without turning it into a process-wide memory sink
