### PR TITLE
Security/semantic dns health probe ssrf

### DIFF
--- a/documentation/semantic-dns.md
+++ b/documentation/semantic-dns.md
@@ -274,6 +274,13 @@ When a service record includes attributes such as `health_check_path`,
 can refresh the active service record from a real HTTP endpoint before it
 answers discovery, topology, or route questions.
 
+That probe path is intentionally not a free outbound fetch primitive. Probe
+targets are now gated by the operator-owned `king.dns_live_probe_allowed_hosts`
+allowlist, which defaults to loopback-only (`localhost`, `127.0.0.1`, `::1`).
+Non-loopback probe targets must be explicitly allowlisted at system level
+before Semantic-DNS will open a socket to them, and probe request hosts and
+paths are rejected when they contain unsafe request-line or header characters.
+
 When Semantic-DNS persistence is enabled, King also treats those writes as a
 shared control-plane state problem instead of a local array update. Concurrent
 service registration, status changes, and probe-driven refreshes are serialized

--- a/extension/include/config/smart_dns/base_layer.h
+++ b/extension/include/config/smart_dns/base_layer.h
@@ -33,6 +33,7 @@ typedef struct _kg_smart_dns_config_t {
     /* --- Semantic DNS & Mothernode --- */
     bool semantic_mode_enable;
     char *mothernode_uri;
+    char *live_probe_allowed_hosts;
 } kg_smart_dns_config_t;
 
 /* Module-global configuration instance. */

--- a/extension/src/config/config.c
+++ b/extension/src/config/config.c
@@ -124,6 +124,7 @@ void king_config_release_module_globals(void)
     memset(&king_smart_contracts_config, 0, sizeof(king_smart_contracts_config));
 
     KING_CONFIG_FREE_PERSISTENT(king_smart_dns_config.mode);
+    KING_CONFIG_FREE_PERSISTENT(king_smart_dns_config.live_probe_allowed_hosts);
     memset(&king_smart_dns_config, 0, sizeof(king_smart_dns_config));
 
     king_config_free_ssh_strings(&king_ssh_over_quic_config);

--- a/extension/src/config/internal/owned_strings.inc
+++ b/extension/src/config/internal/owned_strings.inc
@@ -50,6 +50,7 @@ static void king_config_free_dns_strings(kg_smart_dns_config_t *dns)
     pefree(dns->server_bind_host, 1);
     pefree(dns->mode, 1);
     pefree(dns->mothernode_uri, 1);
+    pefree(dns->live_probe_allowed_hosts, 1);
 }
 
 static void king_config_free_otel_strings(kg_open_telemetry_config_t *otel)
@@ -162,6 +163,7 @@ static void king_config_clone_owned_strings(king_cfg_t *cfg)
     cfg->dns.server_bind_host = king_config_clone_persistent_string(cfg->dns.server_bind_host);
     cfg->dns.mode = king_config_clone_persistent_string(cfg->dns.mode);
     cfg->dns.mothernode_uri = king_config_clone_persistent_string(cfg->dns.mothernode_uri);
+    cfg->dns.live_probe_allowed_hosts = king_config_clone_persistent_string(cfg->dns.live_probe_allowed_hosts);
     cfg->owns_dns_strings = 1;
 
     cfg->observability.service_name = king_config_clone_persistent_string(cfg->observability.service_name);

--- a/extension/src/config/smart_dns/config.c
+++ b/extension/src/config/smart_dns/config.c
@@ -58,6 +58,17 @@ static int kg_smart_dns_reject_unsupported_setting(const char *setting_name)
     return FAILURE;
 }
 
+static int kg_smart_dns_reject_system_only_setting(const char *setting_name)
+{
+    zend_throw_exception_ex(
+        spl_ce_InvalidArgumentException,
+        0,
+        "Smart-DNS v1 treats %s as a system-only setting.",
+        setting_name
+    );
+    return FAILURE;
+}
+
 int kg_config_smart_dns_apply_userland_config_to(
     kg_smart_dns_config_t *target,
     zval *config_arr)
@@ -118,6 +129,8 @@ int kg_config_smart_dns_apply_userland_config_to(
             return kg_smart_dns_reject_unsupported_setting("dns.recursive_forwarders");
         } else if (zend_string_equals_literal(key, "dns_health_agent_mcp_endpoint")) {
             return kg_smart_dns_reject_unsupported_setting("dns.health_agent_mcp_endpoint");
+        } else if (zend_string_equals_literal(key, "dns_live_probe_allowed_hosts")) {
+            return kg_smart_dns_reject_system_only_setting("dns.live_probe_allowed_hosts");
         } else if (zend_string_equals_literal(key, "dns_mothernode_uri")) {
             if (kg_validate_string(value, &target->mothernode_uri) != SUCCESS) {
                 return FAILURE;

--- a/extension/src/config/smart_dns/default.c
+++ b/extension/src/config/smart_dns/default.c
@@ -13,4 +13,5 @@ void kg_config_smart_dns_defaults_load(void)
 
     king_smart_dns_config.semantic_mode_enable = false;
     king_smart_dns_config.mothernode_uri = NULL;
+    king_smart_dns_config.live_probe_allowed_hosts = NULL;
 }

--- a/extension/src/config/smart_dns/ini.c
+++ b/extension/src/config/smart_dns/ini.c
@@ -5,6 +5,8 @@
 #include <ext/spl/spl_exceptions.h>
 #include <zend_ini.h>
 #include <zend_exceptions.h>
+#include <ctype.h>
+#include <string.h>
 
 static void king_smart_dns_replace_string(char **target, zend_string *value)
 {
@@ -13,6 +15,82 @@ static void king_smart_dns_replace_string(char **target, zend_string *value)
     }
 
     *target = pestrdup(ZSTR_VAL(value), 1);
+}
+
+static char *king_smart_dns_trim_ascii_whitespace(char *value)
+{
+    char *start = value;
+    size_t length;
+
+    if (value == NULL) {
+        return NULL;
+    }
+
+    while (*start == ' ' || *start == '\t' || *start == '\r' || *start == '\n') {
+        start++;
+    }
+
+    length = strlen(start);
+    while (length > 0
+        && (start[length - 1] == ' '
+            || start[length - 1] == '\t'
+            || start[length - 1] == '\r'
+            || start[length - 1] == '\n')) {
+        start[length - 1] = '\0';
+        length--;
+    }
+
+    return start;
+}
+
+static bool king_smart_dns_probe_host_entry_is_valid(const char *value)
+{
+    const unsigned char *cursor = (const unsigned char *) value;
+
+    if (value == NULL || value[0] == '\0') {
+        return false;
+    }
+
+    while (*cursor != '\0') {
+        if (!isalnum(*cursor) && *cursor != '.' && *cursor != '-' && *cursor != ':') {
+            return false;
+        }
+        cursor++;
+    }
+
+    return true;
+}
+
+static ZEND_INI_MH(OnUpdateDnsProbeHostAllowlist)
+{
+    char *allowlist_copy;
+    char *saveptr = NULL;
+    char *host_entry;
+
+    allowlist_copy = estrndup(ZSTR_VAL(new_value), ZSTR_LEN(new_value));
+    if (allowlist_copy == NULL) {
+        return FAILURE;
+    }
+
+    for (host_entry = strtok_r(allowlist_copy, ",", &saveptr);
+         host_entry != NULL;
+         host_entry = strtok_r(NULL, ",", &saveptr)) {
+        char *trimmed = king_smart_dns_trim_ascii_whitespace(host_entry);
+
+        if (trimmed == NULL || !king_smart_dns_probe_host_entry_is_valid(trimmed)) {
+            efree(allowlist_copy);
+            zend_throw_exception_ex(
+                spl_ce_InvalidArgumentException,
+                0,
+                "Invalid value for king.dns_live_probe_allowed_hosts. Provide a comma-separated list of hostnames or IP literals."
+            );
+            return FAILURE;
+        }
+    }
+
+    efree(allowlist_copy);
+    king_smart_dns_replace_string(&king_smart_dns_config.live_probe_allowed_hosts, new_value);
+    return SUCCESS;
 }
 
 static ZEND_INI_MH(OnUpdateDnsPositiveLong)
@@ -63,6 +141,8 @@ PHP_INI_BEGIN()
         OnUpdateDnsPositiveLong, service_discovery_max_ips_per_response, kg_smart_dns_config_t, king_smart_dns_config)
     STD_PHP_INI_ENTRY("king.dns_semantic_mode_enable", "0", PHP_INI_SYSTEM,
         OnUpdateBool, semantic_mode_enable, kg_smart_dns_config_t, king_smart_dns_config)
+    ZEND_INI_ENTRY_EX("king.dns_live_probe_allowed_hosts", "localhost,127.0.0.1,::1", PHP_INI_SYSTEM,
+        OnUpdateDnsProbeHostAllowlist, NULL)
     STD_PHP_INI_ENTRY("king.dns_mothernode_uri", "", PHP_INI_SYSTEM,
         OnUpdateString, mothernode_uri, kg_smart_dns_config_t, king_smart_dns_config)
 PHP_INI_END()

--- a/extension/src/core/introspection/semantic_dns/live_signals.inc
+++ b/extension/src/core/introspection/semantic_dns/live_signals.inc
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
@@ -80,6 +81,97 @@ static zend_string *king_semantic_dns_probe_service_path(
     }
 
     return Z_STR_P(attribute);
+}
+
+static char *king_semantic_dns_trim_ascii_whitespace(char *value);
+
+static bool king_semantic_dns_probe_host_has_safe_characters(zend_string *host)
+{
+    size_t index;
+
+    if (host == NULL || ZSTR_LEN(host) == 0) {
+        return false;
+    }
+
+    for (index = 0; index < ZSTR_LEN(host); index++) {
+        unsigned char ch = (unsigned char) ZSTR_VAL(host)[index];
+
+        if (!isalnum(ch) && ch != '.' && ch != '-' && ch != ':') {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool king_semantic_dns_probe_path_is_safe(zend_string *path)
+{
+    size_t index;
+
+    if (path == NULL || ZSTR_LEN(path) == 0 || ZSTR_VAL(path)[0] != '/') {
+        return false;
+    }
+
+    for (index = 0; index < ZSTR_LEN(path); index++) {
+        unsigned char ch = (unsigned char) ZSTR_VAL(path)[index];
+
+        if (ch <= 0x20 || ch == 0x7f) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool king_semantic_dns_probe_host_matches_allowlist_entry(
+    zend_string *host,
+    const char *entry
+)
+{
+    size_t entry_len;
+
+    if (host == NULL || entry == NULL) {
+        return false;
+    }
+
+    entry_len = strlen(entry);
+    return entry_len == ZSTR_LEN(host)
+        && strncasecmp(entry, ZSTR_VAL(host), entry_len) == 0;
+}
+
+static bool king_semantic_dns_probe_host_is_allowed(zend_string *host)
+{
+    char *allowlist_copy;
+    char *entry;
+    char *saveptr = NULL;
+    bool allowed = false;
+
+    if (!king_semantic_dns_probe_host_has_safe_characters(host)
+        || king_smart_dns_config.live_probe_allowed_hosts == NULL
+        || king_smart_dns_config.live_probe_allowed_hosts[0] == '\0') {
+        return false;
+    }
+
+    allowlist_copy = estrdup(king_smart_dns_config.live_probe_allowed_hosts);
+    if (allowlist_copy == NULL) {
+        return false;
+    }
+
+    for (entry = strtok_r(allowlist_copy, ",", &saveptr);
+         entry != NULL;
+         entry = strtok_r(NULL, ",", &saveptr)) {
+        char *trimmed = king_semantic_dns_trim_ascii_whitespace(entry);
+
+        if (trimmed != NULL
+            && trimmed[0] != '\0'
+            && king_semantic_dns_probe_host_matches_allowlist_entry(host, trimmed)) {
+            allowed = true;
+            break;
+        }
+    }
+
+    efree(allowlist_copy);
+    return allowed;
 }
 
 static char *king_semantic_dns_trim_ascii_whitespace(char *value)
@@ -221,7 +313,7 @@ static bool king_semantic_dns_probe_service_live_state(
 {
     zend_string *probe_path = king_semantic_dns_probe_service_path(service);
     zend_string *probe_host;
-    zend_string *transport_target;
+    zend_string *transport_target = NULL;
     zend_string *transport_error = NULL;
     php_stream *stream = NULL;
     struct timeval timeout;
@@ -243,11 +335,26 @@ static bool king_semantic_dns_probe_service_live_state(
     }
 
     probe_host = king_semantic_dns_probe_service_host(service);
+    if (probe_host == NULL
+        || !king_semantic_dns_probe_path_is_safe(probe_path)
+        || !king_semantic_dns_probe_host_is_allowed(probe_host)) {
+        return king_semantic_dns_service_apply_probe_snapshot(
+            service,
+            "unhealthy",
+            service->current_load_percent,
+            service->active_connections,
+            service->total_requests,
+            false,
+            false,
+            false
+        );
+    }
+
     transport_target = king_semantic_dns_build_probe_transport_target(
         probe_host,
         king_semantic_dns_probe_service_port(service)
     );
-    if (probe_host == NULL || transport_target == NULL || ZSTR_VAL(probe_path)[0] != '/') {
+    if (transport_target == NULL) {
         return king_semantic_dns_service_apply_probe_snapshot(
             service,
             "unhealthy",
@@ -296,13 +403,28 @@ static bool king_semantic_dns_probe_service_live_state(
     php_stream_set_option(stream, PHP_STREAM_OPTION_BLOCKING, 1, NULL);
     php_stream_set_option(stream, PHP_STREAM_OPTION_READ_TIMEOUT, 0, &timeout);
 
-    snprintf(
+    {
+        int request_length = snprintf(
         request_buffer,
         sizeof(request_buffer),
         "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n",
         ZSTR_VAL(probe_path),
         ZSTR_VAL(probe_host)
-    );
+        );
+        if (request_length < 0 || (size_t) request_length >= sizeof(request_buffer)) {
+            php_stream_close(stream);
+            return king_semantic_dns_service_apply_probe_snapshot(
+                service,
+                "unhealthy",
+                service->current_load_percent,
+                service->active_connections,
+                service->total_requests,
+                false,
+                false,
+                false
+            );
+        }
+    }
 
     if (php_stream_write(stream, request_buffer, strlen(request_buffer)) != (ssize_t) strlen(request_buffer)) {
         probe_failed = true;

--- a/extension/src/core/introspection/system.inc
+++ b/extension/src/core/introspection/system.inc
@@ -206,6 +206,8 @@ PHP_FUNCTION(king_system_get_component_info)
             king_smart_dns_config.service_discovery_max_ips_per_response);
         add_assoc_bool(&configuration, "semantic_mode_enable",
             king_smart_dns_config.semantic_mode_enable ? 1 : 0);
+        add_assoc_string(&configuration, "live_probe_allowed_hosts",
+            king_safe_string(king_smart_dns_config.live_probe_allowed_hosts));
         add_assoc_string(&configuration, "mothernode_uri",
             king_safe_string(king_smart_dns_config.mothernode_uri));
     } else if (zend_string_equals_literal(component_name, "mcp")) {

--- a/extension/tests/030-system-component-info-config-backed-matrix.phpt
+++ b/extension/tests/030-system-component-info-config-backed-matrix.phpt
@@ -185,7 +185,7 @@ array(6) {
 }
 string(12) "semantic_dns"
 string(13) "config_backed"
-array(8) {
+array(9) {
   [0]=>
   string(13) "server_enable"
   [1]=>
@@ -201,6 +201,8 @@ array(8) {
   [6]=>
   string(20) "semantic_mode_enable"
   [7]=>
+  string(24) "live_probe_allowed_hosts"
+  [8]=>
   string(14) "mothernode_uri"
 }
 bool(true)

--- a/extension/tests/331-smart-dns-config-surface-honesty.phpt
+++ b/extension/tests/331-smart-dns-config-surface-honesty.phpt
@@ -82,7 +82,7 @@ Semantic-DNS v1 does not support init option 'health_check_interval_ms'.
 King\ValidationException
 Semantic-DNS v1 does not support init option 'mothernode_sync_interval_sec'.
 bool(true)
-array(8) {
+array(9) {
   [0]=>
   string(13) "server_enable"
   [1]=>
@@ -98,5 +98,7 @@ array(8) {
   [6]=>
   string(20) "semantic_mode_enable"
   [7]=>
+  string(24) "live_probe_allowed_hosts"
+  [8]=>
   string(14) "mothernode_uri"
 }

--- a/extension/tests/460-semantic-dns-live-probe-allowlisted-override-contract.phpt
+++ b/extension/tests/460-semantic-dns-live-probe-allowlisted-override-contract.phpt
@@ -1,0 +1,66 @@
+--TEST--
+King semantic DNS live probes honor allowlisted host and port override attributes
+--INI--
+king.security_allow_config_override=1
+king.dns_live_probe_allowed_hosts=127.0.0.1
+--FILE--
+<?php
+require __DIR__ . '/semantic_dns_live_probe_helper.inc';
+
+$serverState = tempnam(sys_get_temp_dir(), 'king-semantic-dns-live-allow-');
+king_semantic_dns_live_probe_write_state($serverState, [
+    'http_status' => 200,
+    'status' => 'healthy',
+    'current_load_percent' => 7,
+    'active_connections' => 11,
+    'total_requests' => 120,
+]);
+$server = king_semantic_dns_live_probe_start_server($serverState);
+
+try {
+    var_dump(king_semantic_dns_init([
+        'enabled' => true,
+        'bind_address' => '127.0.0.1',
+        'dns_port' => 5353,
+        'default_record_ttl_sec' => 60,
+        'service_discovery_max_ips_per_response' => 8,
+    ]));
+    var_dump(king_semantic_dns_start_server());
+    var_dump(king_semantic_dns_register_service([
+        'service_id' => 'svc-a',
+        'service_name' => 'global-chat-api',
+        'service_type' => 'http_server',
+        'hostname' => 'chat-a.internal',
+        'port' => 9443,
+        'status' => 'healthy',
+        'current_load_percent' => 99,
+        'active_connections' => 999,
+        'total_requests' => 9999,
+        'attributes' => [
+            'health_check_host' => '127.0.0.1',
+            'health_check_port' => $server['port'],
+            'health_check_path' => '/health',
+        ],
+    ]));
+
+    $route = king_semantic_dns_get_optimal_route('global-chat-api');
+    var_dump($route['service_id'] === 'svc-a');
+    var_dump($route['current_load_percent'] === 7);
+    var_dump($route['active_connections'] === 11);
+    var_dump($route['total_requests'] === 120);
+} finally {
+    $capture = king_semantic_dns_live_probe_stop_server($server);
+    var_dump(($capture['request_count'] ?? 0) >= 1);
+    var_dump(($capture['requests'][0]['request_line'] ?? null) === 'GET /health HTTP/1.1');
+}
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/extension/tests/461-semantic-dns-live-probe-host-allowlist-hardening.phpt
+++ b/extension/tests/461-semantic-dns-live-probe-host-allowlist-hardening.phpt
@@ -1,0 +1,64 @@
+--TEST--
+King semantic DNS refuses live probe targets outside the configured host allowlist
+--INI--
+king.security_allow_config_override=1
+king.dns_live_probe_allowed_hosts=localhost
+--FILE--
+<?php
+require __DIR__ . '/semantic_dns_live_probe_helper.inc';
+
+$serverState = tempnam(sys_get_temp_dir(), 'king-semantic-dns-live-block-');
+king_semantic_dns_live_probe_write_state($serverState, [
+    'http_status' => 200,
+    'status' => 'healthy',
+    'current_load_percent' => 1,
+    'active_connections' => 1,
+    'total_requests' => 1,
+]);
+$server = king_semantic_dns_live_probe_start_server($serverState);
+
+try {
+    var_dump(king_semantic_dns_init([
+        'enabled' => true,
+        'bind_address' => '127.0.0.1',
+        'dns_port' => 5353,
+        'default_record_ttl_sec' => 60,
+        'service_discovery_max_ips_per_response' => 8,
+    ]));
+    var_dump(king_semantic_dns_start_server());
+    var_dump(king_semantic_dns_register_service([
+        'service_id' => 'svc-blocked',
+        'service_name' => 'blocked-api',
+        'service_type' => 'http_server',
+        'hostname' => 'api.internal',
+        'port' => 9443,
+        'status' => 'healthy',
+        'current_load_percent' => 1,
+        'active_connections' => 1,
+        'total_requests' => 1,
+        'attributes' => [
+            'health_check_host' => '127.0.0.1',
+            'health_check_port' => $server['port'],
+            'health_check_path' => '/health',
+        ],
+    ]));
+
+    $route = king_semantic_dns_get_optimal_route('blocked-api');
+    $topology = king_semantic_dns_get_service_topology();
+
+    var_dump($route['service_id'] === null);
+    var_dump($route['error'] === 'No healthy service found');
+    var_dump($topology['statistics']['unhealthy_services'] === 1);
+} finally {
+    $capture = king_semantic_dns_live_probe_stop_server($server);
+    var_dump(($capture['request_count'] ?? 0) === 0);
+}
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/extension/tests/462-semantic-dns-live-probe-request-sanitization-contract.phpt
+++ b/extension/tests/462-semantic-dns-live-probe-request-sanitization-contract.phpt
@@ -1,0 +1,64 @@
+--TEST--
+King semantic DNS rejects injected live probe request paths before opening outbound connections
+--INI--
+king.security_allow_config_override=1
+king.dns_live_probe_allowed_hosts=127.0.0.1
+--FILE--
+<?php
+require __DIR__ . '/semantic_dns_live_probe_helper.inc';
+
+$serverState = tempnam(sys_get_temp_dir(), 'king-semantic-dns-live-path-');
+king_semantic_dns_live_probe_write_state($serverState, [
+    'http_status' => 200,
+    'status' => 'healthy',
+    'current_load_percent' => 1,
+    'active_connections' => 1,
+    'total_requests' => 1,
+]);
+$server = king_semantic_dns_live_probe_start_server($serverState);
+
+try {
+    var_dump(king_semantic_dns_init([
+        'enabled' => true,
+        'bind_address' => '127.0.0.1',
+        'dns_port' => 5353,
+        'default_record_ttl_sec' => 60,
+        'service_discovery_max_ips_per_response' => 8,
+    ]));
+    var_dump(king_semantic_dns_start_server());
+    var_dump(king_semantic_dns_register_service([
+        'service_id' => 'svc-path',
+        'service_name' => 'path-injected-api',
+        'service_type' => 'http_server',
+        'hostname' => '127.0.0.1',
+        'port' => 9443,
+        'status' => 'healthy',
+        'current_load_percent' => 1,
+        'active_connections' => 1,
+        'total_requests' => 1,
+        'attributes' => [
+            'health_check_host' => '127.0.0.1',
+            'health_check_port' => $server['port'],
+            'health_check_path' => "/health\r\nX-Evil: yes",
+        ],
+    ]));
+
+    $route = king_semantic_dns_get_optimal_route('path-injected-api');
+    $topology = king_semantic_dns_get_service_topology();
+
+    var_dump($route['service_id'] === null);
+    var_dump($route['error'] === 'No healthy service found');
+    var_dump($topology['statistics']['unhealthy_services'] === 1);
+} finally {
+    $capture = king_semantic_dns_live_probe_stop_server($server);
+    var_dump(($capture['request_count'] ?? 0) === 0);
+}
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Title:
Harden semantic DNS live health probes against SSRF

Description:
This PR hardens Semantic DNS live health probes so service attributes can no longer steer arbitrary outbound probe traffic.

Included:
- loopback-only probe targets by default
- a system-only allowlist for non-loopback live probe hosts
- rejection of unsafe host/path values before probe request construction
- regression coverage for allowlisted overrides, host hardening, and request sanitization

Impact:
- closes the blind-SSRF primitive in live probe construction
- keeps live probes usable while making the default trust boundary explicit and much tighter
