### PR TITLE
[codex] Remediate open code scanning alerts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -131,14 +131,27 @@ jobs:
             latest: true
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.artifact-gate.outputs.trusted-checkout-ref }}
-          fetch-depth: 0
+      - name: Download trusted source tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_CHECKOUT_REF: ${{ needs.artifact-gate.outputs.trusted-checkout-ref }}
+        run: |
+          set -euo pipefail
 
-      - name: Fetch tags
-        run: git fetch --force --tags origin '+refs/tags/*:refs/tags/*'
+          case "${TRUSTED_CHECKOUT_REF}" in
+            refs/heads/main|refs/heads/develop|refs/tags/v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "Refusing to download untrusted source ref: ${TRUSTED_CHECKOUT_REF}"
+              exit 1
+              ;;
+          esac
+
+          archive_path="${RUNNER_TEMP}/king-source.tar.gz"
+          api_path="/repos/${GITHUB_REPOSITORY}/tarball/${TRUSTED_CHECKOUT_REF}"
+
+          gh api "${api_path}" > "${archive_path}"
+          find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          tar -xzf "${archive_path}" --strip-components=1
 
       - name: Download amd64 release package
         env:
@@ -263,14 +276,27 @@ jobs:
             latest: true
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.artifact-gate.outputs.trusted-checkout-ref }}
-          fetch-depth: 0
+      - name: Download trusted source tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_CHECKOUT_REF: ${{ needs.artifact-gate.outputs.trusted-checkout-ref }}
+        run: |
+          set -euo pipefail
 
-      - name: Fetch tags
-        run: git fetch --force --tags origin '+refs/tags/*:refs/tags/*'
+          case "${TRUSTED_CHECKOUT_REF}" in
+            refs/heads/main|refs/heads/develop|refs/tags/v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "Refusing to download untrusted source ref: ${TRUSTED_CHECKOUT_REF}"
+              exit 1
+              ;;
+          esac
+
+          archive_path="${RUNNER_TEMP}/king-source.tar.gz"
+          api_path="/repos/${GITHUB_REPOSITORY}/tarball/${TRUSTED_CHECKOUT_REF}"
+
+          gh api "${api_path}" > "${archive_path}"
+          find . -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          tar -xzf "${archive_path}" --strip-components=1
 
       - name: Download amd64 release package
         env:

--- a/extension/src/object_store/internal/object_store_distributed_backend.inc
+++ b/extension/src/object_store/internal/object_store_distributed_backend.inc
@@ -357,7 +357,7 @@ static int king_object_store_distributed_read_internal(
         return FAILURE;
     }
 
-    if (stat(file_path, &st) != 0) {
+    if (king_object_store_open_regular_file_stream_readonly(file_path, &fp, &st) != SUCCESS) {
         if (errno == ENOENT) {
             return KING_OBJECT_STORE_RESULT_MISS;
         }
@@ -384,19 +384,6 @@ static int king_object_store_distributed_read_internal(
         } else if (king_object_store_metadata_is_expired_now(metadata)) {
             return FAILURE;
         }
-    }
-
-    fp = fopen(file_path, "rb");
-    if (fp == NULL) {
-        king_object_store_set_backend_filesystem_error(
-            error,
-            error_size,
-            "distributed",
-            "read",
-            object_id,
-            strerror(errno)
-        );
-        return FAILURE;
     }
 
     *data_size = (size_t) st.st_size;
@@ -494,7 +481,7 @@ static int king_object_store_distributed_read_range_internal(
     *data = NULL;
     *data_size = 0;
 
-    if (stat(file_path, &st) != 0 || !S_ISREG(st.st_mode)) {
+    if (king_object_store_open_regular_file_stream_readonly(file_path, &fp, &st) != SUCCESS) {
         if (errno == ENOENT) {
             return KING_OBJECT_STORE_RESULT_MISS;
         }
@@ -543,18 +530,6 @@ static int king_object_store_distributed_read_range_internal(
         bytes_to_read = length;
     }
 
-    fp = fopen(file_path, "rb");
-    if (fp == NULL) {
-        king_object_store_set_backend_filesystem_error(
-            error,
-            error_size,
-            "distributed",
-            "range read",
-            object_id,
-            strerror(errno)
-        );
-        return FAILURE;
-    }
     if (fseeko(fp, (off_t) offset, SEEK_SET) != 0) {
         fclose(fp);
         king_object_store_set_backend_filesystem_error(
@@ -989,4 +964,3 @@ static int king_object_store_distributed_remove_with_real_backup_semantics(const
 }
 
 /* --- CDN stubs --- */
-

--- a/extension/src/object_store/internal/object_store_local_fs_io.inc
+++ b/extension/src/object_store/internal/object_store_local_fs_io.inc
@@ -68,6 +68,62 @@ static int king_object_store_ensure_directory_recursive(const char *path)
     return king_object_store_ensure_directory(path);
 }
 
+static int king_object_store_open_regular_file_stream_readonly(
+    const char *path,
+    FILE **fp_out,
+    struct stat *st_out
+)
+{
+    int fd;
+    int flags = O_RDONLY;
+    FILE *fp;
+    struct stat st;
+    int saved_errno;
+
+    if (path == NULL || fp_out == NULL) {
+        return FAILURE;
+    }
+
+#ifdef O_CLOEXEC
+    flags |= O_CLOEXEC;
+#endif
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+
+    fd = open(path, flags);
+    if (fd < 0) {
+        return FAILURE;
+    }
+
+    if (fstat(fd, &st) != 0) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return FAILURE;
+    }
+
+    if (!S_ISREG(st.st_mode)) {
+        close(fd);
+        errno = EINVAL;
+        return FAILURE;
+    }
+
+    fp = fdopen(fd, "rb");
+    if (fp == NULL) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return FAILURE;
+    }
+
+    if (st_out != NULL) {
+        *st_out = st;
+    }
+    *fp_out = fp;
+    return SUCCESS;
+}
+
 static int king_object_store_atomic_write_file(const char *target_path, const void *data, size_t data_size)
 {
     FILE *fp;
@@ -271,7 +327,7 @@ static int king_object_store_read_file_contents(
         return FAILURE;
     }
 
-    if (stat(source_path, &st) != 0 || !S_ISREG(st.st_mode)) {
+    if (king_object_store_open_regular_file_stream_readonly(source_path, &fp, &st) != SUCCESS) {
         return FAILURE;
     }
 
@@ -279,14 +335,7 @@ static int king_object_store_read_file_contents(
     *data = pemalloc(*data_size + 1, 1);
     if (*data == NULL) {
         *data_size = 0;
-        return FAILURE;
-    }
-
-    fp = fopen(source_path, "rb");
-    if (fp == NULL) {
-        pefree(*data, 1);
-        *data = NULL;
-        *data_size = 0;
+        fclose(fp);
         return FAILURE;
     }
 

--- a/extension/src/object_store/internal/object_store_local_fs_primary.inc
+++ b/extension/src/object_store/internal/object_store_local_fs_primary.inc
@@ -304,7 +304,7 @@ int king_object_store_local_fs_read(
 
     king_object_store_build_path(file_path, sizeof(file_path), object_id);
 
-    if (stat(file_path, &st) != 0) {
+    if (king_object_store_open_regular_file_stream_readonly(file_path, &fp, &st) != SUCCESS) {
         if (errno == ENOENT) {
             return KING_OBJECT_STORE_RESULT_MISS;
         }
@@ -323,12 +323,6 @@ int king_object_store_local_fs_read(
         } else if (king_object_store_metadata_is_expired_now(metadata)) {
             return FAILURE;
         }
-    }
-
-    fp = fopen(file_path, "rb");
-    if (fp == NULL) {
-        king_object_store_set_local_failure_error("read", object_id, strerror(errno));
-        return FAILURE;
     }
 
     *data_size = st.st_size;
@@ -395,7 +389,7 @@ int king_object_store_local_fs_read_range(
     *data_size = 0;
 
     king_object_store_build_path(file_path, sizeof(file_path), object_id);
-    if (stat(file_path, &st) != 0 || !S_ISREG(st.st_mode)) {
+    if (king_object_store_open_regular_file_stream_readonly(file_path, &fp, &st) != SUCCESS) {
         if (errno == ENOENT) {
             return KING_OBJECT_STORE_RESULT_MISS;
         }
@@ -433,11 +427,6 @@ int king_object_store_local_fs_read_range(
         bytes_to_read = length;
     }
 
-    fp = fopen(file_path, "rb");
-    if (fp == NULL) {
-        king_object_store_set_local_failure_error("range read", object_id, strerror(errno));
-        return FAILURE;
-    }
     if (fseeko(fp, (off_t) offset, SEEK_SET) != 0) {
         fclose(fp);
         king_object_store_set_local_failure_error("range read", object_id, "could not seek to the requested offset.");
@@ -665,4 +654,3 @@ int king_object_store_local_fs_list(zval *return_array)
     closedir(dir);
     return SUCCESS;
 }
-


### PR DESCRIPTION
This PR remediates the currently open code-scanning findings on `main`.

Included:
- remove privileged `workflow_run` checkouts from the Docker publish workflow and replace them with a trusted-ref tarball download path
- eliminate TOCTOU `stat()` -> `fopen()` races in local and distributed object-store read paths by opening the file descriptor first, validating it with `fstat()`, and only then wrapping it as a stream

Impact:
- closes the remaining `actions/untrusted-checkout/high` findings in `.github/workflows/docker.yml`
- closes the open filesystem race findings in the object-store local/distributed read paths
- keeps the fixes narrow to the flagged code paths without changing the public object-store contract

Validation:
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/check-stub-parity.sh`
- `./infra/scripts/test-extension.sh tests/123-object-store-multi-backend.phpt tests/411-object-store-real-backend-routing-matrix.phpt tests/425-object-store-core-metadata-range-versioning-contract.phpt tests/427-object-store-cloud-core-metadata-range-versioning-contract.phpt tests/448-object-store-localfs-distributed-backup-contract.phpt`