### PR TITLE
[codex] Harden object-store snapshot filesystem transitions

### DIFF
--- a/extension/src/object_store/internal/object_store_capacity_transfer.inc
+++ b/extension/src/object_store/internal/object_store_capacity_transfer.inc
@@ -47,18 +47,8 @@ static int king_object_store_build_snapshot_manifest_path(
 
 static int king_object_store_remove_tree(const char *path)
 {
-    struct stat st;
-
     if (path == NULL || path[0] == '\0') {
         return FAILURE;
-    }
-
-    if (lstat(path, &st) != 0) {
-        return errno == ENOENT ? SUCCESS : FAILURE;
-    }
-
-    if (!S_ISDIR(st.st_mode)) {
-        return unlink(path) == 0 ? SUCCESS : FAILURE;
     }
 
     {
@@ -66,6 +56,12 @@ static int king_object_store_remove_tree(const char *path)
         struct dirent *entry;
 
         if (dir == NULL) {
+            if (errno == ENOENT) {
+                return SUCCESS;
+            }
+            if (errno == ENOTDIR) {
+                return unlink(path) == 0 ? SUCCESS : FAILURE;
+            }
             return FAILURE;
         }
 
@@ -999,7 +995,6 @@ static int king_object_store_commit_snapshot_directory(
     const char *destination_directory
 )
 {
-    struct stat st;
     char previous_directory[1024];
     zend_bool had_existing_destination = 0;
 
@@ -1010,25 +1005,28 @@ static int king_object_store_commit_snapshot_directory(
 
     previous_directory[0] = '\0';
 
-    if (stat(destination_directory, &st) == 0) {
-        if (!S_ISDIR(st.st_mode)) {
+    if (king_object_store_create_unique_directory(
+            destination_directory,
+            "previous",
+            previous_directory,
+            sizeof(previous_directory)
+        ) != SUCCESS) {
+        return FAILURE;
+    }
+    if (rmdir(previous_directory) != 0) {
+        king_object_store_remove_tree(previous_directory);
+        return FAILURE;
+    }
+
+    if (rename(destination_directory, previous_directory) == 0) {
+        DIR *moved_directory = opendir(previous_directory);
+
+        if (moved_directory == NULL) {
+            (void) rename(previous_directory, destination_directory);
             return FAILURE;
         }
-        if (king_object_store_create_unique_directory(
-                destination_directory,
-                "previous",
-                previous_directory,
-                sizeof(previous_directory)
-            ) != SUCCESS) {
-            return FAILURE;
-        }
-        if (rmdir(previous_directory) != 0) {
-            king_object_store_remove_tree(previous_directory);
-            return FAILURE;
-        }
-        if (rename(destination_directory, previous_directory) != 0) {
-            return FAILURE;
-        }
+
+        closedir(moved_directory);
         had_existing_destination = 1;
     } else if (errno != ENOENT) {
         return FAILURE;


### PR DESCRIPTION
This PR addresses the remaining object-store snapshot/restore filesystem race findings still reported by GitHub security scanning.

Included:
- removes pre-check-based `lstat`/`stat` patterns from snapshot tree removal and snapshot directory commit paths
- switches the affected flows to operation-first handling so file-system transitions are not validated and then used through a stale path check
- keeps rollback behavior for snapshot directory swaps while avoiding the previously flagged TOCTOU structure
- preserves the committed backup/incremental restore contracts already merged on `main`

Validation:
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/check-stub-parity.sh`
- `./infra/scripts/test-extension.sh tests/305-object-store-backup-restore.phpt tests/313-object-store-backup-restore-path-hardening.phpt tests/465-object-store-backup-snapshot-consistency-contract.phpt tests/466-object-store-backup-restore-locking-contract.phpt tests/467-object-store-incremental-backup-contract.phpt tests/468-object-store-incremental-backup-options-contract.phpt tests/469-object-store-incremental-restore-corruption-fail-closed-contract.phpt tests/470-object-store-legacy-restore-corruption-fail-closed-contract.phpt tests/471-object-store-restore-concurrent-mutation-failclosed-contract.phpt tests/472-object-store-restore-global-mutation-barrier-contract.phpt tests/473-object-store-range-fd-leak-regression-contract.phpt tests/474-object-store-control-character-id-hardening-contract.phpt`
