### PR TITLE
[codex] Fix Copilot PR follow-up findings

### DIFF
--- a/extension/include/object_store/object_store_internal.h
+++ b/extension/include/object_store/object_store_internal.h
@@ -89,6 +89,7 @@ int king_object_store_local_fs_list(zval *return_array);
 int king_object_store_list_object(zval *return_array);
 int king_object_store_backend_read_metadata(const char *object_id, king_object_metadata_t *metadata);
 const char *king_object_store_object_id_validate(const char *object_id);
+const char *king_object_store_public_object_id_validate_zstr(const zend_string *object_id);
 void king_object_store_compute_sha256_hex(const void *data, size_t data_size, char output[65]);
 zend_bool king_object_store_runtime_capacity_is_enabled(void);
 const char *king_object_store_runtime_capacity_mode_to_string(void);

--- a/extension/src/core/introspection/object_store/cdn.inc
+++ b/extension/src/core/introspection/object_store/cdn.inc
@@ -25,13 +25,14 @@ PHP_FUNCTION(king_cdn_cache_object)
         zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID cannot be empty");
         RETURN_THROWS();
     }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
+
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     if (!king_cdn_cache_registry_initialized) {
@@ -170,11 +171,6 @@ PHP_FUNCTION(king_cdn_invalidate_cache)
         RETURN_THROWS();
     }
 
-    if (object_id != NULL && ZSTR_LEN(object_id) == 0) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID cannot be empty");
-        RETURN_THROWS();
-    }
-
     if (object_id == NULL) {
         /* Flush all (including expired) */
         zend_long removed_count = (zend_long) zend_hash_num_elements(&king_cdn_cache_registry);
@@ -182,13 +178,18 @@ PHP_FUNCTION(king_cdn_invalidate_cache)
         RETURN_LONG(removed_count);
     }
 
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
+    if (ZSTR_LEN(object_id) == 0) {
+        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID cannot be empty");
         RETURN_THROWS();
+    }
+
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     /* Single-object invalidation */

--- a/extension/src/core/introspection/object_store/registry.inc
+++ b/extension/src/core/introspection/object_store/registry.inc
@@ -1100,17 +1100,13 @@ PHP_FUNCTION(king_object_store_put)
         RETURN_THROWS();
     }
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID must be between 1 and 127 bytes.");
-        RETURN_THROWS();
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     if (!king_object_store_registry_acquire_mutation_lock(
@@ -1196,17 +1192,13 @@ PHP_FUNCTION(king_object_store_put_from_stream)
         RETURN_THROWS();
     }
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID must be between 1 and 127 bytes.");
-        RETURN_THROWS();
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     stream = king_object_store_registry_fetch_stream_resource(stream_zv, 2, "king_object_store_put_from_stream");
@@ -1323,13 +1315,13 @@ PHP_FUNCTION(king_object_store_begin_resumable_upload)
         zend_throw_exception_ex(king_ce_runtime_exception, 0, "Object-store registry is unavailable.");
         RETURN_THROWS();
     }
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID must be between 1 and 127 bytes.");
-        RETURN_THROWS();
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID is invalid for object-store paths.");
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     memset(&metadata, 0, sizeof(metadata));
@@ -1564,17 +1556,13 @@ PHP_FUNCTION(king_object_store_get)
         Z_PARAM_ARRAY_OR_NULL(options)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID must be between 1 and 127 bytes.");
-        RETURN_THROWS();
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     if (!king_object_store_registry_extract_range_options(
@@ -1649,17 +1637,13 @@ PHP_FUNCTION(king_object_store_get_to_stream)
         Z_PARAM_ARRAY_OR_NULL(options)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID must be between 1 and 127 bytes.");
-        RETURN_THROWS();
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     destination_stream = king_object_store_registry_fetch_stream_resource(stream_zv, 2, "king_object_store_get_to_stream");
@@ -1721,17 +1705,13 @@ PHP_FUNCTION(king_object_store_delete)
         Z_PARAM_STR(object_id)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(king_ce_validation_exception, 0, "Object ID must be between 1 and 127 bytes.");
-        RETURN_THROWS();
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(king_ce_validation_exception, 0, "%s", object_id_error);
+            RETURN_THROWS();
+        }
     }
 
     if (!king_object_store_runtime.initialized) {
@@ -1838,10 +1818,7 @@ PHP_FUNCTION(king_object_store_get_metadata)
     if (!king_object_store_runtime.initialized) {
         return;
     }
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        return;
-    }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
+    if (king_object_store_public_object_id_validate_zstr(object_id) != NULL) {
         return;
     }
 
@@ -1954,22 +1931,20 @@ PHP_FUNCTION(king_object_store_backup_object)
         Z_PARAM_STR(destination_path)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID must be between 1 and 127 bytes."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(
+                king_ce_validation_exception,
+                0,
+                "%s",
+                object_id_error
+            );
+            RETURN_THROWS();
+        }
     }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
-    }
+
     if (ZSTR_LEN(destination_path) == 0) {
         zend_throw_exception_ex(
             king_ce_validation_exception,
@@ -2006,22 +1981,20 @@ PHP_FUNCTION(king_object_store_restore_object)
         Z_PARAM_STR(source_path)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID must be between 1 and 127 bytes."
-        );
-        RETURN_THROWS();
+    {
+        const char *object_id_error = king_object_store_public_object_id_validate_zstr(object_id);
+
+        if (object_id_error != NULL) {
+            zend_throw_exception_ex(
+                king_ce_validation_exception,
+                0,
+                "%s",
+                object_id_error
+            );
+            RETURN_THROWS();
+        }
     }
-    if (king_object_store_object_id_validate(ZSTR_VAL(object_id)) != NULL) {
-        zend_throw_exception_ex(
-            king_ce_validation_exception,
-            0,
-            "Object ID is invalid for object-store paths."
-        );
-        RETURN_THROWS();
-    }
+
     if (ZSTR_LEN(source_path) == 0) {
         zend_throw_exception_ex(
             king_ce_validation_exception,

--- a/extension/src/object_store/internal/object_store_backend_contracts.inc
+++ b/extension/src/object_store/internal/object_store_backend_contracts.inc
@@ -887,6 +887,27 @@ const char *king_object_store_object_id_validate(const char *object_id)
     return NULL;
 }
 
+const char *king_object_store_public_object_id_validate_zstr(const zend_string *object_id)
+{
+    const unsigned char *cursor;
+    size_t index;
+
+    if (object_id == NULL || ZSTR_LEN(object_id) == 0 || ZSTR_LEN(object_id) > 127) {
+        return "Object ID must be between 1 and 127 bytes.";
+    }
+
+    cursor = (const unsigned char *) ZSTR_VAL(object_id);
+    for (index = 0; index < ZSTR_LEN(object_id); index++) {
+        if (cursor[index] < 0x20 || cursor[index] == 0x7f) {
+            return "Object ID is invalid for object-store paths.";
+        }
+    }
+
+    return king_object_store_object_id_validate(ZSTR_VAL(object_id)) == NULL
+        ? NULL
+        : "Object ID is invalid for object-store paths.";
+}
+
 /* --- Config helpers --- */
 
 static void king_object_store_config_clear(king_object_store_config_t *config)

--- a/extension/src/object_store/internal/object_store_capacity_transfer.inc
+++ b/extension/src/object_store/internal/object_store_capacity_transfer.inc
@@ -534,11 +534,13 @@ static int king_object_store_snapshot_manifest_parse(
 )
 {
     FILE *fp;
-    char line[640];
+    char *line = NULL;
+    size_t line_capacity = 0;
     int saw_format = 0;
     int saw_kind = 0;
     int saw_consistency = 0;
     char pending_inventory_object_id[128] = {0};
+    int status = FAILURE;
 
     if (manifest_path == NULL || manifest_path[0] == '\0'
         || inventory == NULL || Z_TYPE_P(inventory) != IS_ARRAY
@@ -554,7 +556,7 @@ static int king_object_store_snapshot_manifest_parse(
         return FAILURE;
     }
 
-    while (fgets(line, sizeof(line), fp) != NULL) {
+    while (getline(&line, &line_capacity, fp) != -1) {
         char *value = strchr(line, '=');
         size_t value_len;
 
@@ -571,8 +573,7 @@ static int king_object_store_snapshot_manifest_parse(
 
         if (strcmp(line, "format") == 0) {
             if (strcmp(value, KING_OBJECT_STORE_SNAPSHOT_MANIFEST_FORMAT) != 0) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
             saw_format = 1;
             continue;
@@ -580,8 +581,7 @@ static int king_object_store_snapshot_manifest_parse(
         if (strcmp(line, "kind") == 0) {
             if (strcmp(value, KING_OBJECT_STORE_SNAPSHOT_MANIFEST_KIND_FULL) != 0
                 && strcmp(value, KING_OBJECT_STORE_SNAPSHOT_MANIFEST_KIND_INCREMENTAL) != 0) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
             snprintf(kind_out, kind_out_size, "%s", value);
             saw_kind = 1;
@@ -589,8 +589,7 @@ static int king_object_store_snapshot_manifest_parse(
         }
         if (strcmp(line, "consistency") == 0) {
             if (strcmp(value, KING_OBJECT_STORE_SNAPSHOT_MANIFEST_CONSISTENCY) != 0) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
             saw_consistency = 1;
             continue;
@@ -598,8 +597,7 @@ static int king_object_store_snapshot_manifest_parse(
         if (strcmp(line, "inventory_object_id") == 0) {
             if (pending_inventory_object_id[0] != '\0'
                 || king_object_store_object_id_validate(value) != NULL) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
 
             snprintf(
@@ -618,8 +616,7 @@ static int king_object_store_snapshot_manifest_parse(
                     pending_inventory_object_id,
                     value
                 ) != SUCCESS) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
 
             pending_inventory_object_id[0] = '\0';
@@ -628,33 +625,35 @@ static int king_object_store_snapshot_manifest_parse(
         if (strcmp(line, "object_id") == 0 || strcmp(line, "upsert_object_id") == 0) {
             if (king_object_store_object_id_validate(value) != NULL
                 || king_object_store_snapshot_string_list_push(upserts, value) != SUCCESS) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
             if (strcmp(line, "object_id") == 0
                 && zend_hash_str_find(Z_ARRVAL_P(inventory), value, strlen(value)) == NULL
                 && king_object_store_snapshot_inventory_set(inventory, value, "") != SUCCESS) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
             continue;
         }
         if (strcmp(line, "delete_object_id") == 0) {
             if (king_object_store_object_id_validate(value) != NULL
                 || king_object_store_snapshot_string_list_push(deletes, value) != SUCCESS) {
-                fclose(fp);
-                return FAILURE;
+                goto cleanup;
             }
         }
     }
 
-    fclose(fp);
-
     if (pending_inventory_object_id[0] != '\0') {
-        return FAILURE;
+        goto cleanup;
     }
 
-    return (saw_format && saw_kind && saw_consistency) ? SUCCESS : FAILURE;
+    status = (saw_format && saw_kind && saw_consistency) ? SUCCESS : FAILURE;
+
+cleanup:
+    if (line != NULL) {
+        free(line);
+    }
+    fclose(fp);
+    return status;
 }
 
 static int king_object_store_snapshot_manifest_validate_restore_shape(

--- a/extension/tests/474-object-store-control-character-id-hardening-contract.phpt
+++ b/extension/tests/474-object-store-control-character-id-hardening-contract.phpt
@@ -16,6 +16,11 @@ var_dump(king_object_store_init([
 $badIds = [
     "evil\nformat=bad",
     "evil\rkind=full",
+    "evil\tformat=bad",
+    "evil\0format=bad",
+    "evil\fform=bad",
+    "evil\vformat=bad",
+    "evil\x7fform=bad",
 ];
 
 foreach ($badIds as $badId) {
@@ -43,6 +48,36 @@ foreach (scandir($root) as $file) {
 ?>
 --EXPECT--
 bool(true)
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
+string(24) "King\ValidationException"
+string(44) "Object ID is invalid for object-store paths."
 string(24) "King\ValidationException"
 string(44) "Object ID is invalid for object-store paths."
 string(24) "King\ValidationException"


### PR DESCRIPTION
This PR addresses the two real issues found while reviewing the open Copilot security-fix PRs.

Included:
- reject embedded NUL bytes and other control characters consistently across the public object-store and CDN object-id entry points
- extend the object-id hardening regression to cover the new public NUL/control-byte cases
- switch snapshot manifest parsing to `getline()` while freeing the dynamic line buffer on every exit path, including malformed-manifest failures

Verification:
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/305-object-store-backup-restore.phpt tests/313-object-store-backup-restore-path-hardening.phpt tests/465-object-store-backup-snapshot-consistency-contract.phpt tests/467-object-store-incremental-backup-contract.phpt tests/469-object-store-incremental-restore-corruption-fail-closed-contract.phpt tests/474-object-store-control-character-id-hardening-contract.phpt`
- `git diff --check`

Notes:
- no `ISSUES.md` changes
- two separate commits, one per logical fix block