### PR TITLE
[codex] Bound snapshot manifest parser line length

### DIFF
--- a/extension/src/object_store/internal/object_store_capacity_transfer.inc
+++ b/extension/src/object_store/internal/object_store_capacity_transfer.inc
@@ -5,6 +5,7 @@
 #define KING_OBJECT_STORE_SNAPSHOT_MANIFEST_KIND_FULL "full_backup"
 #define KING_OBJECT_STORE_SNAPSHOT_MANIFEST_KIND_INCREMENTAL "incremental_backup"
 #define KING_OBJECT_STORE_SNAPSHOT_MANIFEST_CONSISTENCY "per_object_locked_commit"
+#define KING_OBJECT_STORE_SNAPSHOT_MANIFEST_MAX_LINE_LENGTH 4096
 
 #ifndef KING_PATH_MAX
 # if defined(PATH_MAX)
@@ -542,8 +543,7 @@ static int king_object_store_snapshot_manifest_parse(
 )
 {
     FILE *fp;
-    char *line = NULL;
-    size_t line_capacity = 0;
+    char line[KING_OBJECT_STORE_SNAPSHOT_MANIFEST_MAX_LINE_LENGTH];
     int saw_format = 0;
     int saw_kind = 0;
     int saw_consistency = 0;
@@ -564,9 +564,18 @@ static int king_object_store_snapshot_manifest_parse(
         return FAILURE;
     }
 
-    while (getline(&line, &line_capacity, fp) != -1) {
+    while (fgets(line, sizeof(line), fp) != NULL) {
         char *value = strchr(line, '=');
+        size_t line_len = strlen(line);
         size_t value_len;
+
+        if (line_len == sizeof(line) - 1 && line[line_len - 1] != '\n') {
+            int ch;
+
+            while ((ch = fgetc(fp)) != '\n' && ch != EOF) {
+            }
+            goto cleanup;
+        }
 
         if (value == NULL) {
             continue;
@@ -657,9 +666,6 @@ static int king_object_store_snapshot_manifest_parse(
     status = (saw_format && saw_kind && saw_consistency) ? SUCCESS : FAILURE;
 
 cleanup:
-    if (line != NULL) {
-        free(line);
-    }
     fclose(fp);
     return status;
 }

--- a/extension/tests/501-object-store-manifest-line-cap-contract.phpt
+++ b/extension/tests/501-object-store-manifest-line-cap-contract.phpt
@@ -1,0 +1,96 @@
+--TEST--
+King object-store restore rejects oversized snapshot manifest lines without mutating live state
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+
+function king_object_store_501_remove_tree(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+
+    foreach (scandir($path) as $entry) {
+        if ($entry === '.' || $entry === '..') {
+            continue;
+        }
+
+        $child = $path . '/' . $entry;
+        if (is_dir($child)) {
+            king_object_store_501_remove_tree($child);
+            @rmdir($child);
+            continue;
+        }
+
+        @unlink($child);
+    }
+
+    @rmdir($path);
+}
+
+$source = sys_get_temp_dir() . '/king_object_store_manifest_cap_source_501_' . getmypid();
+$target = sys_get_temp_dir() . '/king_object_store_manifest_cap_target_501_' . getmypid();
+$snapshot = $source . '/snapshots/full';
+$import = $target . '/import';
+$manifest = $import . '/.king_snapshot_manifest';
+
+foreach ([$source, $target] as $path) {
+    king_object_store_501_remove_tree($path);
+    @mkdir($path, 0700, true);
+}
+
+king_object_store_init([
+    'storage_root_path' => $source,
+    'primary_backend' => 'local_fs',
+]);
+
+var_dump(king_object_store_put('asset-1', 'alpha-payload'));
+var_dump(king_object_store_backup_all_objects($snapshot));
+
+@mkdir($import, 0700, true);
+foreach (scandir($snapshot) as $entry) {
+    if ($entry === '.' || $entry === '..') {
+        continue;
+    }
+    copy($snapshot . '/' . $entry, $import . '/' . $entry);
+}
+
+file_put_contents(
+    $manifest,
+    (string) file_get_contents($manifest)
+    . 'object_id=' . str_repeat('a', 5000) . "\n"
+);
+
+king_object_store_init([
+    'storage_root_path' => $target,
+    'primary_backend' => 'local_fs',
+]);
+
+var_dump(king_object_store_put('preexisting', 'keep-me'));
+var_dump(king_object_store_restore_all_objects($import));
+var_dump(king_object_store_get('asset-1'));
+var_dump(king_object_store_get('preexisting'));
+
+$all = array_map(
+    static fn(array $entry): string => $entry['object_id'],
+    king_object_store_list()
+);
+sort($all);
+var_dump($all);
+
+foreach ([$source, $target] as $path) {
+    king_object_store_501_remove_tree($path);
+}
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+string(7) "keep-me"
+array(1) {
+  [0]=>
+  string(11) "preexisting"
+}


### PR DESCRIPTION
## Summary
- bound snapshot manifest parsing to a fixed maximum line length instead of using unbounded `getline()` growth
- reject oversized manifest lines fail-closed during restore after draining the remainder of the malformed line
- add a restore regression proving oversized manifests do not mutate live state on failure

## Root Cause
The snapshot manifest parser switched to `getline()`, which allowed arbitrarily large manifest lines to force heap growth during `restore_all_objects()`. Earlier cleanup fixes removed the easy leak path, but the parser still had no hard cap on line length.

## Validation
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/465-object-store-backup-snapshot-consistency-contract.phpt tests/469-object-store-incremental-restore-corruption-fail-closed-contract.phpt tests/470-object-store-legacy-restore-corruption-fail-closed-contract.phpt tests/501-object-store-manifest-line-cap-contract.phpt`
- `git diff --check`