### PR TITLE
[codex] Harden snapshot cleanup against symlink traversal

### DIFF
--- a/extension/src/object_store/internal/object_store_capacity_transfer.inc
+++ b/extension/src/object_store/internal/object_store_capacity_transfer.inc
@@ -55,8 +55,18 @@ static int king_object_store_build_snapshot_manifest_path(
 
 static int king_object_store_remove_tree(const char *path)
 {
+    struct stat st;
+
     if (path == NULL || path[0] == '\0') {
         return FAILURE;
+    }
+
+    if (lstat(path, &st) != 0) {
+        return errno == ENOENT ? SUCCESS : FAILURE;
+    }
+
+    if (!S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)) {
+        return unlink(path) == 0 ? SUCCESS : FAILURE;
     }
 
     {
@@ -64,12 +74,6 @@ static int king_object_store_remove_tree(const char *path)
         struct dirent *entry;
 
         if (dir == NULL) {
-            if (errno == ENOENT) {
-                return SUCCESS;
-            }
-            if (errno == ENOTDIR) {
-                return unlink(path) == 0 ? SUCCESS : FAILURE;
-            }
             return FAILURE;
         }
 

--- a/extension/tests/481-object-store-snapshot-cleanup-symlink-hardening-contract.phpt
+++ b/extension/tests/481-object-store-snapshot-cleanup-symlink-hardening-contract.phpt
@@ -1,0 +1,73 @@
+--TEST--
+King object-store snapshot cleanup does not traverse directory symlinks outside the snapshot tree
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+
+function king_object_store_481_remove_tree(string $path): void
+{
+    if (is_link($path) || is_file($path)) {
+        @unlink($path);
+        return;
+    }
+
+    if (!is_dir($path)) {
+        return;
+    }
+
+    foreach (scandir($path) as $entry) {
+        if ($entry === '.' || $entry === '..') {
+            continue;
+        }
+
+        king_object_store_481_remove_tree($path . '/' . $entry);
+    }
+
+    @rmdir($path);
+}
+
+$primary = sys_get_temp_dir() . '/king_object_store_snapshot_primary_481_' . getmypid();
+$snapshot = $primary . '/snapshots/full';
+$outside = sys_get_temp_dir() . '/king_object_store_snapshot_outside_481_' . getmypid();
+$outside_nested = $outside . '/nested';
+$outside_secret = $outside_nested . '/secret.txt';
+$snapshot_link = $snapshot . '/outside-link';
+
+foreach ([$primary, $outside] as $path) {
+    king_object_store_481_remove_tree($path);
+    @mkdir($path, 0700, true);
+}
+@mkdir($outside_nested, 0700, true);
+file_put_contents($outside_secret, 'keep-me');
+
+king_object_store_init([
+    'storage_root_path' => $primary,
+    'primary_backend' => 'local_fs',
+]);
+
+var_dump(king_object_store_put('asset-1', 'alpha-payload'));
+var_dump(king_object_store_backup_all_objects($snapshot));
+var_dump(symlink($outside_nested, $snapshot_link));
+var_dump(is_link($snapshot_link));
+var_dump(file_exists($outside_secret));
+var_dump(king_object_store_put('asset-2', 'beta-payload'));
+var_dump(king_object_store_backup_all_objects($snapshot));
+var_dump(file_exists($outside_secret));
+var_dump(king_object_store_get('asset-1'));
+var_dump(king_object_store_get('asset-2'));
+
+king_object_store_481_remove_tree($primary);
+king_object_store_481_remove_tree($outside);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+string(13) "alpha-payload"
+string(12) "beta-payload"


### PR DESCRIPTION
## Summary
- stop snapshot cleanup from traversing directory symlinks by classifying paths with `lstat()` before recursion
- treat symlinks and non-directory entries as unlink-only cleanup targets
- add a regression proving repeated `backup_all_objects()` cleanup cannot delete files outside the snapshot tree through an injected symlink

## Root Cause
`king_object_store_remove_tree()` switched to `opendir()`-first recursion. Because `opendir()` follows symlinks, a symlink-to-directory inside a previous snapshot could cause cleanup to recurse into and delete content outside the intended snapshot tree.

## Validation
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/465-object-store-backup-snapshot-consistency-contract.phpt tests/467-object-store-incremental-backup-contract.phpt tests/469-object-store-incremental-restore-corruption-fail-closed-contract.phpt tests/470-object-store-legacy-restore-corruption-fail-closed-contract.phpt tests/481-object-store-snapshot-cleanup-symlink-hardening-contract.phpt`
- `git diff --check`