### PR TITLE
[codex] Terminate remote orchestrator error metadata

### DIFF
--- a/extension/src/pipeline_orchestrator/orchestrator.c
+++ b/extension/src/pipeline_orchestrator/orchestrator.c
@@ -51,11 +51,28 @@ static void king_orchestrator_error_meta_init(king_orchestrator_error_meta_t *me
         return;
     }
 
-    meta->category[0] = '\0';
-    meta->retry_disposition[0] = '\0';
-    meta->backend[0] = '\0';
+    memset(meta, 0, sizeof(*meta));
     meta->step_index = -1;
     meta->has_classification = 0;
+}
+
+static void king_orchestrator_error_meta_copy_bounded(
+    char *destination,
+    size_t destination_size,
+    const char *source
+)
+{
+    if (destination == NULL || destination_size == 0) {
+        return;
+    }
+
+    destination[0] = '\0';
+    if (source == NULL) {
+        return;
+    }
+
+    strncpy(destination, source, destination_size - 1);
+    destination[destination_size - 1] = '\0';
 }
 
 static void king_orchestrator_error_meta_set(
@@ -71,15 +88,13 @@ static void king_orchestrator_error_meta_set(
     }
 
     king_orchestrator_error_meta_init(meta);
-    if (category != NULL) {
-        strncpy(meta->category, category, sizeof(meta->category) - 1);
-    }
-    if (retry_disposition != NULL) {
-        strncpy(meta->retry_disposition, retry_disposition, sizeof(meta->retry_disposition) - 1);
-    }
-    if (backend != NULL) {
-        strncpy(meta->backend, backend, sizeof(meta->backend) - 1);
-    }
+    king_orchestrator_error_meta_copy_bounded(meta->category, sizeof(meta->category), category);
+    king_orchestrator_error_meta_copy_bounded(
+        meta->retry_disposition,
+        sizeof(meta->retry_disposition),
+        retry_disposition
+    );
+    king_orchestrator_error_meta_copy_bounded(meta->backend, sizeof(meta->backend), backend);
     meta->step_index = step_index;
     meta->has_classification = 1;
 }

--- a/extension/tests/502-orchestrator-remote-error-meta-bounded-contract.phpt
+++ b/extension/tests/502-orchestrator-remote-error-meta-bounded-contract.phpt
@@ -1,0 +1,108 @@
+--TEST--
+King pipeline orchestrator bounds remote error metadata strings from remote peers
+--SKIPIF--
+<?php
+if (!function_exists('proc_open') || !function_exists('stream_socket_server')) {
+    echo "skip proc_open and stream_socket_server are required";
+}
+?>
+--FILE--
+<?php
+require __DIR__ . '/orchestrator_remote_peer_helper.inc';
+
+$extensionPath = dirname(__DIR__) . '/modules/king.so';
+$remoteScript = tempnam(sys_get_temp_dir(), 'king-orchestrator-remote-meta-');
+
+file_put_contents($remoteScript, <<<'PHP'
+<?php
+king_pipeline_orchestrator_register_tool('summarizer', [
+    'model' => 'gpt-sim',
+    'max_tokens' => 64,
+]);
+
+try {
+    king_pipeline_orchestrator_run(
+        ['text' => 'remote-long-meta'],
+        unserialize(base64_decode($argv[1]), ['allowed_classes' => false]),
+        ['trace_id' => $argv[2]]
+    );
+    echo "no-exception\n";
+} catch (Throwable $e) {
+    echo get_class($e), "\n";
+}
+
+$run = king_pipeline_orchestrator_get_run(
+    king_system_get_component_info('pipeline_orchestrator')['configuration']['last_run_id']
+);
+echo json_encode([
+    'status' => $run['status'] ?? null,
+    'error_classification' => $run['error_classification'] ?? null,
+], JSON_INVALID_UTF8_SUBSTITUTE), "\n";
+PHP
+);
+
+$runRemoteCase = static function (array $pipeline, string $traceId, array $server) use ($extensionPath, $remoteScript): array {
+    $statePath = tempnam(sys_get_temp_dir(), 'king-orchestrator-remote-meta-state-');
+    @unlink($statePath);
+
+    $command = sprintf(
+        '%s -n -d %s -d %s -d %s -d %s -d %s -d %s %s %s %s',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg('extension=' . $extensionPath),
+        escapeshellarg('king.security_allow_config_override=1'),
+        escapeshellarg('king.orchestrator_execution_backend=remote_peer'),
+        escapeshellarg('king.orchestrator_remote_host=' . $server['host']),
+        escapeshellarg('king.orchestrator_remote_port=' . $server['port']),
+        escapeshellarg('king.orchestrator_state_path=' . $statePath),
+        escapeshellarg($remoteScript),
+        escapeshellarg(base64_encode(serialize($pipeline))),
+        escapeshellarg($traceId)
+    );
+
+    $output = [];
+    $status = -1;
+    exec($command, $output, $status);
+    @unlink($statePath);
+
+    if ($status !== 0) {
+        throw new RuntimeException('remote orchestrator child failed');
+    }
+
+    return [
+        'class' => $output[0] ?? null,
+        'snapshot' => json_decode($output[1] ?? 'null', true),
+    ];
+};
+
+$server = king_orchestrator_remote_peer_start();
+$result = $runRemoteCase(
+    [[
+        'tool' => 'summarizer',
+        'remote_error' => 'forced long remote metadata failure',
+        'remote_error_category' => str_repeat('c', 40),
+        'remote_error_retry_disposition' => str_repeat('r', 41),
+        'remote_error_backend' => str_repeat('b', 39),
+    ]],
+    'remote-long-meta',
+    $server
+);
+$capture = king_orchestrator_remote_peer_stop($server);
+
+var_dump(($result['class'] ?? null) === 'King\\RuntimeException');
+var_dump(($result['snapshot']['status'] ?? null) === 'failed');
+var_dump(($result['snapshot']['error_classification']['category'] ?? null) === str_repeat('c', 31));
+var_dump(($result['snapshot']['error_classification']['retry_disposition'] ?? null) === str_repeat('r', 31));
+var_dump(($result['snapshot']['error_classification']['backend'] ?? null) === str_repeat('b', 31));
+var_dump(($result['snapshot']['error_classification']['step_index'] ?? null) === 0);
+var_dump(($capture['events'][0]['failed_step_index'] ?? null) === 0);
+
+@unlink($remoteScript);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/extension/tests/orchestrator_remote_peer_server.inc
+++ b/extension/tests/orchestrator_remote_peer_server.inc
@@ -142,6 +142,17 @@ while (($client = @stream_socket_accept($server, -1)) !== false) {
         }
 
         if (isset($step['remote_error']) && is_string($step['remote_error'])) {
+            $remoteErrorCategory = (
+                isset($step['remote_error_category']) && is_string($step['remote_error_category'])
+            ) ? $step['remote_error_category'] : 'backend';
+            $remoteErrorRetryDisposition = (
+                isset($step['remote_error_retry_disposition'])
+                && is_string($step['remote_error_retry_disposition'])
+            ) ? $step['remote_error_retry_disposition'] : 'caller_managed_retry';
+            $remoteErrorBackend = (
+                isset($step['remote_error_backend']) && is_string($step['remote_error_backend'])
+            ) ? $step['remote_error_backend'] : 'remote_peer';
+
             $event['remote_error'] = $step['remote_error'];
             $event['failed_step_index'] = $stepIndex;
             king_orchestrator_remote_peer_persist_capture($capture, $capturePath);
@@ -149,10 +160,10 @@ while (($client = @stream_socket_accept($server, -1)) !== false) {
                 $client,
                 $encodeErrorMeta(
                     $step['remote_error'],
-                    'backend',
-                    'caller_managed_retry',
+                    $remoteErrorCategory,
+                    $remoteErrorRetryDisposition,
                     $stepIndex,
-                    'remote_peer'
+                    $remoteErrorBackend
                 )
             );
             $failed = true;


### PR DESCRIPTION
## Summary
- fully zero-initialize orchestrator remote error metadata before use
- copy remote error classification fields through a bounded helper that always NUL-terminates fixed-size buffers
- add a remote-peer regression proving oversized category, retry disposition, and backend strings are truncated safely and persisted without crashes

## Root Cause
Remote peer error metadata was copied into fixed 32-byte buffers with `strncpy(..., size - 1)` after only clearing the first byte of each field. A long remote string could therefore leave the destination unterminated, and the later persistence path used `strlen()` on that buffer.

## Validation
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/497-orchestrator-step-error-classification-contract.phpt tests/502-orchestrator-remote-error-meta-bounded-contract.phpt`
- `git diff --check`