### PR TITLE
[codex] Tighten remaining build and telemetry comments

### DIFF
--- a/extension/config.m4
+++ b/extension/config.m4
@@ -2,8 +2,11 @@ dnl =========================================================================
 dnl config.m4 -- King v1 build
 dnl
 dnl PURPOSE:
-dnl This config.m4 builds a minimal, compilable king extension.
-dnl It has zero external dependencies beyond the PHP build system itself.
+dnl This config.m4 drives the active King extension build with the current
+dnl runtime source list compiled into one shared module.
+dnl Mandatory inputs come from the PHP build toolchain plus the in-tree
+dnl headers the build already probes for, while optional quiche paths can be
+dnl layered in for extended transport builds.
 dnl
 dnl USE:
 dnl   cd extension
@@ -14,8 +17,9 @@ dnl
 dnl This runtime is the integration integrity check. All real subsystem
 dnl implementations are added here as they are transferred from src_bak/.
 dnl
-dnl When the full build is ready, this file will be replaced with the
-dnl production config.m4 that links quiche, libcurl, and OpenSSL.
+dnl Optional quiche wiring is prepared here, but the default active transport
+dnl runtime still stays on the local UDP substrate when no quiche path is
+dnl configured.
 dnl =========================================================================
 
 PHP_ARG_ENABLE([king],

--- a/extension/src/telemetry/telemetry.c
+++ b/extension/src/telemetry/telemetry.c
@@ -1,7 +1,9 @@
 /*
  * Telemetry core runtime for King. Owns trace/log pending buffers, the batched
- * export retry queue, lazy libcurl-based exporter wiring and the small context
- * management helpers behind the current telemetry surface.
+ * export retry queue, lazy libcurl-based exporter wiring and the current small
+ * context helpers. Trace/span creation is live, but the local trace_id and
+ * span_id generators still return fixed placeholder values instead of a real
+ * entropy-backed ID source.
  */
 #include "php_king.h"
 #include "include/telemetry/telemetry.h"
@@ -753,7 +755,7 @@ void king_telemetry_shutdown_system(void)
 char* king_telemetry_generate_trace_id(void)
 {
     static char trace_id[33];
-    /* Simulation: static trace ID for runtime */
+    /* Current runtime still uses a fixed placeholder trace ID. */
     strncpy(trace_id, "4bf92f3577b34da6a3ce929d0e0e4736", 32);
     trace_id[32] = '\0';
     return trace_id;
@@ -762,7 +764,7 @@ char* king_telemetry_generate_trace_id(void)
 char* king_telemetry_generate_span_id(void)
 {
     static char span_id[17];
-    /* Simulation: static span ID for runtime */
+    /* Current runtime still uses a fixed placeholder span ID. */
     strncpy(span_id, "00f067aa0ba902b7", 16);
     span_id[16] = '\0';
     return span_id;


### PR DESCRIPTION
## What changed
- updated `extension/config.m4` header text so it describes the active build file instead of the old minimal placeholder story
- clarified `extension/src/telemetry/telemetry.c` header and inline comments so they explicitly call out the current fixed placeholder trace/span ID generators

## Why
Two comment blocks were still lagging behind the current runtime reality:
- `config.m4` still described itself as a temporary minimal build file that would later be replaced
- `telemetry.c` was improved, but it still did not explicitly acknowledge that trace and span IDs are currently generated from fixed placeholder values

## Impact
- no runtime behavior change
- less comment-to-code drift in two still-historical areas

## Validation
- `git diff --check`