### PR TITLE
[codex] Prebuild HTTP/3 test helpers and add GitHub snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ object-store and control-plane surfaces are real, and the remaining closure
 work is now about narrower hardening, distributed-operating proof, and
 multi-node fleet behavior rather than placeholder subsystem stories.
 
+## GitHub Snapshot
+
+King is a native PHP extension for applications that need real transport,
+control-plane, and infrastructure behavior inside the runtime instead of in
+sidecars. It brings HTTP/1, HTTP/2, HTTP/3, QUIC, TLS, WebSocket, object
+storage, MCP, orchestration, telemetry, autoscaling, and Smart DNS into one
+coherent systems-grade surface for PHP. The project is still alpha, but the
+core runtime is real and the repo is driven by contract tests for transport,
+storage, recovery, and distributed operating paths. If you do not have a
+Hetzner account yet, it is time to fix that. Use the
+[Hetzner Cloud referral link](https://hetzner.cloud/?ref=VYfKUSIni63u) and you
+help support the live infrastructure tests that keep King honest.
+
 King brings the following into one extension:
 
 - QUIC, HTTP/1, HTTP/2, HTTP/3, TLS, streaming, cancellation, and upgrade flows

--- a/infra/scripts/prebuild-http3-test-helpers.sh
+++ b/infra/scripts/prebuild-http3-test-helpers.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TEST_DIR="${ROOT_DIR}/extension/tests"
+QUICHE_DIR="${ROOT_DIR}/quiche"
+MANIFEST="${QUICHE_DIR}/apps/Cargo.toml"
+BIN_DIR="${QUICHE_DIR}/apps/src/bin"
+TARGET_DIR="${QUICHE_DIR}/target/release"
+
+if [[ ! -f "${MANIFEST}" ]]; then
+    exit 0
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    exit 0
+fi
+
+mkdir -p "${BIN_DIR}"
+
+helpers=(
+    "king-http3-failure-peer:http3_failure_peer.rs"
+    "king-http3-delayed-body-client:http3_delayed_body_client.rs"
+    "king-http3-abort-client:http3_abort_client.rs"
+    "king-http3-multi-peer:http3_multi_peer.rs"
+)
+
+bin_args=()
+
+for entry in "${helpers[@]}"; do
+    helper_name="${entry%%:*}"
+    template_name="${entry##*:}"
+    template_path="${TEST_DIR}/${template_name}"
+    source_path="${BIN_DIR}/${helper_name}.rs"
+    binary_path="${TARGET_DIR}/${helper_name}"
+
+    if [[ ! -f "${template_path}" ]]; then
+        echo "Missing tracked HTTP/3 helper template: ${template_path}" >&2
+        exit 1
+    fi
+
+    if [[ ! -f "${source_path}" ]] || ! cmp -s "${template_path}" "${source_path}"; then
+        cp "${template_path}" "${source_path}"
+    fi
+
+    if [[ ! -x "${binary_path}" || "${binary_path}" -ot "${template_path}" || "${binary_path}" -ot "${source_path}" ]]; then
+        bin_args+=(--bin "${helper_name}")
+    fi
+done
+
+if [[ "${#bin_args[@]}" -eq 0 ]]; then
+    exit 0
+fi
+
+cargo build \
+    --manifest-path "${MANIFEST}" \
+    --release \
+    --locked \
+    "${bin_args[@]}"

--- a/infra/scripts/test-extension.sh
+++ b/infra/scripts/test-extension.sh
@@ -34,6 +34,8 @@ export KING_QUICHE_LIBRARY="${QUICHE_LIB}"
 export KING_QUICHE_SERVER="${QUICHE_SERVER}"
 export LD_LIBRARY_PATH="${EXT_DIR}/../quiche/target/release${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
+"${SCRIPT_DIR}/prebuild-http3-test-helpers.sh"
+
 if [[ "$#" -gt 0 ]]; then
     exec "${PHP_BIN}" run-tests.php -q -d "extension=${EXT_SO}" "$@"
 fi


### PR DESCRIPTION
## Summary
- prebuild the tracked HTTP/3 PHPT helper binaries before the suite starts instead of letting individual tests compile them inside the PHPT process
- keep the helper sources synchronized from the tracked Rust templates into `quiche/apps/src/bin` before building
- add a short GitHub-facing README snapshot with the Hetzner referral link

## Root cause
The red canonical run was not showing one shared HTTP/3 runtime regression. Four of the five failures were coming from helper binary compilation inside the PHPT process, and the delayed-body contract also timed out on the same cold helper path. Moving those helper builds into the normal shell-driven test entry path makes the build deterministic and removes the extra cargo work from the PHPT timeout window.

## Why this shape
The runtime contracts in `449`, `486`, `487`, `488`, and `494` already pass once the helpers exist. The narrow fix is therefore to make helper preparation explicit in `infra/scripts/test-extension.sh` rather than weakening the tests or changing the HTTP/3/server behavior.

## Validation
- `../infra/scripts/build-profile.sh release`
- `./infra/scripts/test-extension.sh tests/449-http3-one-shot-delayed-body-completion-contract.phpt tests/486-http3-multi-backpressure-contract.phpt tests/487-http3-sustained-fairness-contract.phpt tests/488-http3-long-duration-soak-contract.phpt tests/494-server-cancel-callbacks-real-traffic-contract.phpt`
- `./infra/scripts/test-extension.sh`
- `bash -n infra/scripts/prebuild-http3-test-helpers.sh infra/scripts/test-extension.sh`
- `git diff --check`

## User-visible impact
The canonical baseline no longer depends on PHPT-internal cargo builds for the tracked HTTP/3 helper clients and peers, and the repo front page now carries the requested short GitHub snapshot plus Hetzner referral link.