### PR TITLE
[codex] Securely clear replaced TLS session tickets

### DIFF
--- a/extension/include/client/session.h
+++ b/extension/include/client/session.h
@@ -181,6 +181,7 @@ king_client_session_t *king_client_session_fetch_resource(
 
 void king_client_session_free(void *session_ptr);
 void king_client_session_close_socket(king_client_session_t *session);
+void king_client_session_clear_tls_ticket(king_client_session_t *session);
 
 zend_result king_client_session_mark_cancelled(
     king_client_session_t *session,

--- a/extension/src/client/session/state/init.inc
+++ b/extension/src/client/session/state/init.inc
@@ -93,11 +93,17 @@ void king_client_session_init_cancel_state(king_client_session_t *session)
 
 static void king_client_session_init_tls_config_from_global(king_client_session_t *session)
 {
-    session->tls_ticket_source = "none";
+    if (session->tls_session_ticket == NULL || ZSTR_LEN(session->tls_session_ticket) == 0) {
+        session->tls_ticket_source = "none";
+        session->tls_has_session_ticket = false;
+        session->tls_session_ticket_length = 0;
+    } else {
+        session->tls_has_session_ticket = true;
+        session->tls_session_ticket_length = (zend_long) ZSTR_LEN(session->tls_session_ticket);
+    }
+
     session->tls_session_ticket_lifetime_sec = king_tls_and_crypto_config.tls_session_ticket_lifetime_sec;
     session->tls_enable_early_data = king_tls_and_crypto_config.tls_enable_early_data;
-    session->tls_has_session_ticket = false;
-    session->tls_session_ticket_length = 0;
 
     king_client_session_set_string(
         &session->tls_default_ca_file,
@@ -115,7 +121,6 @@ static void king_client_session_init_tls_config_from_global(king_client_session_
         &session->tls_ticket_key_file,
         king_tls_and_crypto_config.tls_ticket_key_file
     );
-    king_client_session_set_string(&session->tls_session_ticket, "");
 }
 
 void king_client_session_init_tls_state(king_client_session_t *session)

--- a/extension/src/client/session/state/resource.inc
+++ b/extension/src/client/session/state/resource.inc
@@ -139,12 +139,7 @@ void king_client_session_free(void *session_ptr)
         zend_string_release(session->tls_ticket_key_file);
     }
 
-    if (session->tls_session_ticket != NULL) {
-        if (ZSTR_LEN(session->tls_session_ticket) > 0) {
-            king_secure_zero(ZSTR_VAL(session->tls_session_ticket), ZSTR_LEN(session->tls_session_ticket));
-        }
-        zend_string_release(session->tls_session_ticket);
-    }
+    king_client_session_clear_tls_ticket(session);
 
     if (session->transport_backend != NULL) {
         zend_string_release(session->transport_backend);

--- a/extension/src/client/session/state/tls.inc
+++ b/extension/src/client/session/state/tls.inc
@@ -11,6 +11,28 @@
  * =========================================================================
  */
 
+void king_client_session_clear_tls_ticket(king_client_session_t *session)
+{
+    if (session == NULL) {
+        return;
+    }
+
+    if (session->tls_session_ticket != NULL) {
+        if (ZSTR_LEN(session->tls_session_ticket) > 0) {
+            king_secure_zero(
+                ZSTR_VAL(session->tls_session_ticket),
+                ZSTR_LEN(session->tls_session_ticket)
+            );
+        }
+        zend_string_release(session->tls_session_ticket);
+        session->tls_session_ticket = NULL;
+    }
+
+    session->tls_has_session_ticket = false;
+    session->tls_session_ticket_length = 0;
+    session->tls_ticket_source = "none";
+}
+
 zend_result king_client_session_store_tls_ticket(
     king_client_session_t *session,
     const uint8_t *ticket,
@@ -29,10 +51,11 @@ zend_result king_client_session_store_tls_ticket(
         return FAILURE;
     }
 
-    king_client_session_set_string_bytes(
-        &session->tls_session_ticket,
+    king_client_session_clear_tls_ticket(session);
+    session->tls_session_ticket = zend_string_init(
         (const char *) ticket,
-        len
+        len,
+        0
     );
     session->tls_session_ticket_length = (zend_long) len;
     session->tls_has_session_ticket = true;

--- a/extension/tests/524-tls-ticket-replacement-contract.phpt
+++ b/extension/tests/524-tls-ticket-replacement-contract.phpt
@@ -1,0 +1,36 @@
+--TEST--
+King TLS ticket replacement keeps only the latest ticket across session and ring state
+--FILE--
+<?php
+$sessionA = king_connect('127.0.0.1', 443);
+var_dump(king_client_tls_import_session_ticket($sessionA, 'ticket-A'));
+var_dump(bin2hex(king_client_tls_export_session_ticket($sessionA)));
+
+var_dump(king_client_tls_import_session_ticket($sessionA, 'ticket-BB'));
+var_dump(bin2hex(king_client_tls_export_session_ticket($sessionA)));
+
+$statsA = king_get_stats($sessionA);
+var_dump($statsA['tls_has_session_ticket']);
+var_dump($statsA['tls_ticket_source']);
+var_dump($statsA['tls_session_ticket_length']);
+
+$sessionB = king_connect('127.0.0.1', 443);
+var_dump(bin2hex(king_client_tls_export_session_ticket($sessionB)));
+
+$statsB = king_get_stats($sessionB);
+var_dump($statsB['tls_has_session_ticket']);
+var_dump($statsB['tls_ticket_source']);
+var_dump($statsB['tls_session_ticket_length']);
+?>
+--EXPECT--
+bool(true)
+string(16) "7469636b65742d41"
+bool(true)
+string(18) "7469636b65742d4242"
+bool(true)
+string(8) "imported"
+int(9)
+string(18) "7469636b65742d4242"
+bool(true)
+string(4) "ring"
+int(9)


### PR DESCRIPTION
## What changed

This hardens the client session TLS ticket path so replaced ticket bytes are securely zeroized before release, and the TLS config sync helper no longer clears an already loaded ticket.

It also adds a regression contract proving that replacing a ticket updates both the live session snapshot and the shared ticket ring with only the latest ticket.

## Why

The previous ticket replacement path reused the generic session string helper, which released the old `zend_string` without scrubbing its contents first. That left prior TLS session ticket bytes in heap memory until reuse, and made the ticket path too easy to regress back into an accidental post-load wipe.

## User impact

`king_connect()` and explicit ticket import paths keep TLS resumption state intact, and replacing a session ticket no longer leaves the previous ticket bytes behind in process heap memory.

## Root cause

TLS session tickets were treated like ordinary session strings. The generic string-slot helper frees old strings with `zend_string_release()` only, while secure zeroization previously happened only during final session teardown.

## Validation

- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/128-tls-session-ticket-import-export.phpt tests/129-tls-ticket-ring-reuse.phpt tests/130-tls-runtime-validation.phpt tests/380-http3-session-ticket-reuse-contract.phpt tests/505-http3-quic-tls-lifecycle-churn-contract.phpt tests/524-tls-ticket-replacement-contract.phpt`
- `./infra/scripts/test-extension.sh`
- `git diff --check`
