### PR TITLE
[codex] Reject self-signed admin API client certs

### DIFF
--- a/documentation/13-admin-api-and-tls-reload/README.md
+++ b/documentation/13-admin-api-and-tls-reload/README.md
@@ -54,8 +54,9 @@ application access.
 
 Mutual TLS matters because an admin surface should not trust the network by
 default. It should trust explicit identity. That means the admin path does not
-only present a server certificate. It also verifies the client certificate and
-decides whether the caller belongs on that control surface at all.
+only present a server certificate. It also verifies the client certificate
+chain against the configured CA and decides whether the caller belongs on that
+control surface at all. A random self-signed client leaf is not enough.
 
 This matters because TLS is more than transport encryption. In this context it
 is part of access control. The process is not only protecting bytes on the
@@ -67,7 +68,7 @@ sequenceDiagram
     participant Server as King admin listener
 
     Client->>Server: Connect with client certificate
-    Server->>Server: Verify CA chain and peer identity
+    Server->>Server: Verify client cert chain against the configured CA
     Server->>Client: Accept or reject connection
     Note over Server: Application can inspect peer subject after acceptance
 ```

--- a/documentation/system-ini-reference.md
+++ b/documentation/system-ini-reference.md
@@ -225,7 +225,7 @@ scope.
 | `king.admin_api_bind_host` | `127.0.0.1` | Sets the host or interface used by the admin API listener. |
 | `king.admin_api_port` | `2019` | Sets the admin API port. |
 | `king.admin_api_auth_mode` | `mtls` | Selects the authentication mode used by the admin API listener. |
-| `king.admin_api_ca_file` | unset | Points at the CA file used to verify admin API client certificates. |
+| `king.admin_api_ca_file` | unset | Points at the CA file used to verify admin API client certificate chains; arbitrary self-signed leaf certificates are rejected. |
 | `king.admin_api_cert_file` | unset | Points at the server certificate file used by the admin API listener. |
 | `king.admin_api_key_file` | unset | Points at the private key file used by the admin API listener. |
 | `king.security_allow_config_override` | `0` | Allows or forbids userland runtime configuration overrides. |

--- a/extension/src/server/admin_api.c
+++ b/extension/src/server/admin_api.c
@@ -792,7 +792,8 @@ static zend_result king_server_admin_api_open_listener_stream(
     king_server_admin_api_context_set_string(context, "ssl", "cafile", config->ca_file);
     king_server_admin_api_context_set_bool(context, "ssl", "verify_peer", true);
     king_server_admin_api_context_set_bool(context, "ssl", "verify_peer_name", false);
-    king_server_admin_api_context_set_bool(context, "ssl", "allow_self_signed", true);
+    /* Admin mTLS must stay anchored to the configured CA trust root. */
+    king_server_admin_api_context_set_bool(context, "ssl", "allow_self_signed", false);
     king_server_admin_api_context_set_bool(context, "ssl", "capture_peer_cert", true);
 
     endpoint = strpprintf(

--- a/extension/tests/525-admin-api-self-signed-client-rejection-contract.phpt
+++ b/extension/tests/525-admin-api-self-signed-client-rejection-contract.phpt
@@ -1,0 +1,51 @@
+--TEST--
+King admin API rejects self-signed client certificates outside the configured CA trust
+--SKIPIF--
+<?php
+if (trim((string) shell_exec('command -v openssl')) === '') {
+    echo "skip openssl is required for the admin API TLS fixture";
+}
+?>
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+require __DIR__ . '/server_admin_api_wire_helper.inc';
+
+$fixture = king_server_admin_api_create_tls_fixture();
+
+try {
+    $server = king_server_admin_api_start_server($fixture);
+    $rogueAccepted = false;
+
+    try {
+        $rogueClient = king_server_admin_api_connect_retry_with_profile(
+            $server['port'],
+            $fixture,
+            'rogue_self_signed'
+        );
+        @fwrite(
+            $rogueClient,
+            "GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+        );
+        $rogueResponse = (string) @stream_get_contents($rogueClient);
+        fclose($rogueClient);
+
+        $rogueAccepted = king_server_admin_api_parse_response($rogueResponse)['status'] === 200;
+    } catch (Throwable $e) {
+        $rogueAccepted = false;
+    } finally {
+        $capture = king_server_admin_api_stop_server($server);
+    }
+
+    var_dump($rogueAccepted);
+    var_dump($capture['listen_result']);
+    var_dump(str_contains((string) $capture['error'], 'failed the admin TLS/mTLS handshake'));
+} finally {
+    king_server_admin_api_cleanup_tls_fixture($fixture);
+}
+?>
+--EXPECT--
+bool(false)
+bool(false)
+bool(true)

--- a/extension/tests/server_admin_api_wire_helper.inc
+++ b/extension/tests/server_admin_api_wire_helper.inc
@@ -22,6 +22,9 @@ function king_server_admin_api_create_tls_fixture(): array
         'client_key' => $dir . '/client.key',
         'client_csr' => $dir . '/client.csr',
         'client_cert' => $dir . '/client.pem',
+        'rogue_client_key' => $dir . '/rogue-client.key',
+        'rogue_client_csr' => $dir . '/rogue-client.csr',
+        'rogue_client_cert' => $dir . '/rogue-client.pem',
         'server_ext' => $dir . '/server.ext',
         'client_ext' => $dir . '/client.ext',
     ];
@@ -88,6 +91,20 @@ function king_server_admin_api_create_tls_fixture(): array
             escapeshellarg($fixture['client_cert']),
             escapeshellarg($fixture['client_ext'])
         ),
+        sprintf('openssl genrsa -out %s 2048', escapeshellarg($fixture['rogue_client_key'])),
+        sprintf(
+            'openssl req -new -key %s -out %s -subj %s 2>/dev/null',
+            escapeshellarg($fixture['rogue_client_key']),
+            escapeshellarg($fixture['rogue_client_csr']),
+            escapeshellarg('/CN=KingAdminRogue')
+        ),
+        sprintf(
+            'openssl x509 -req -in %s -signkey %s -out %s -sha256 -days 1 -extfile %s 2>/dev/null',
+            escapeshellarg($fixture['rogue_client_csr']),
+            escapeshellarg($fixture['rogue_client_key']),
+            escapeshellarg($fixture['rogue_client_cert']),
+            escapeshellarg($fixture['client_ext'])
+        ),
     ];
 
     foreach ($commands as $command) {
@@ -107,6 +124,9 @@ function king_server_admin_api_cleanup_tls_fixture(array $fixture): void
         'client_cert',
         'client_csr',
         'client_key',
+        'rogue_client_cert',
+        'rogue_client_csr',
+        'rogue_client_key',
         'reload_cert',
         'reload_csr',
         'reload_key',
@@ -218,6 +238,20 @@ function king_server_admin_api_connect_retry(
     bool $withClientCert = true,
     int $timeoutMs = 3000
 ) {
+    return king_server_admin_api_connect_retry_with_profile(
+        $port,
+        $fixture,
+        $withClientCert ? 'trusted' : 'none',
+        $timeoutMs
+    );
+}
+
+function king_server_admin_api_connect_retry_with_profile(
+    int $port,
+    array $fixture,
+    string $clientProfile = 'trusted',
+    int $timeoutMs = 3000
+) {
     $deadline = microtime(true) + ($timeoutMs / 1000);
     $errstr = 'connection failed';
 
@@ -226,11 +260,22 @@ function king_server_admin_api_connect_retry(
             'cafile' => $fixture['ca_cert'],
             'verify_peer' => true,
             'verify_peer_name' => false,
-            'allow_self_signed' => true,
+            'allow_self_signed' => false,
         ];
-        if ($withClientCert) {
-            $sslOptions['local_cert'] = $fixture['client_cert'];
-            $sslOptions['local_pk'] = $fixture['client_key'];
+
+        switch ($clientProfile) {
+            case 'trusted':
+                $sslOptions['local_cert'] = $fixture['client_cert'];
+                $sslOptions['local_pk'] = $fixture['client_key'];
+                break;
+            case 'rogue_self_signed':
+                $sslOptions['local_cert'] = $fixture['rogue_client_cert'];
+                $sslOptions['local_pk'] = $fixture['rogue_client_key'];
+                break;
+            case 'none':
+                break;
+            default:
+                throw new RuntimeException('unknown admin API client profile');
         }
 
         $client = @stream_socket_client(


### PR DESCRIPTION
## What changed

This removes `allow_self_signed` from the on-wire admin API listener's TLS context so mTLS is anchored to the configured CA instead of accepting arbitrary self-signed client leaf certificates.

It also extends the admin API wire harness with a rogue self-signed client fixture and adds a dedicated regression contract proving that a self-signed client outside the configured CA trust cannot reach the listener.

## Why

The admin API advertises `auth_mode = mtls` and requires a CA file specifically for client-certificate verification. Allowing self-signed client certificates at the TLS layer undermines that trust boundary and turns the admin plane into an authentication bypass when exposed.

## User impact

Operators still use the same CA/cert/key settings, but admin clients must now chain to the configured CA. Random self-signed client certificates no longer satisfy the admin API's mTLS gate.

## Root cause

The TLS listener context enabled `verify_peer` and `cafile`, but also set `allow_self_signed = true`. That weakened the intended CA-based client authentication policy and left no app-level backstop after the handshake.

## Validation

- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/212-server-control-shutdown-contracts.phpt tests/220-admin-api-listen-local-runtime.phpt tests/221-admin-api-validation.phpt tests/222-server-tls-reload-local-runtime.phpt tests/223-server-tls-reload-validation.phpt tests/507-server-admin-api-real-traffic-contract.phpt tests/525-admin-api-self-signed-client-rejection-contract.phpt`
- `./infra/scripts/test-extension.sh`
- `git diff --check`
