### PR TITLE
[codex] Add first PIE install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,23 @@ Canonical release-install verification then runs through
 `./infra/scripts/container-smoke-matrix.sh`.
 The supported host/runtime verification matrix spans PHP `8.1` through `8.5`.
 
+## PIE
+
+King now carries the first honest maintainer surface for
+[PIE](https://github.com/php/pie), the PHP Installer for Extensions.
+
+The intended package shape is:
+
+- root [`composer.json`](composer.json) with `type = php-ext`
+- `build-path = extension`
+- a pre-packaged source asset built with
+  [`./infra/scripts/package-pie-source.sh`](infra/scripts/package-pie-source.sh)
+
+That source asset is the important part. King cannot rely on the default
+repository ZIP for PIE because the bundled `quiche/` tree is part of the active
+build. The maintainer workflow is documented in
+[`documentation/pie-install.md`](documentation/pie-install.md).
+
 ## Contributing
 
 See [CONTRIBUTE.md](CONTRIBUTE.md).

--- a/README.md
+++ b/README.md
@@ -28,18 +28,153 @@ object-store and control-plane surfaces are real, and the remaining closure
 work is now about narrower hardening, distributed-operating proof, and
 multi-node fleet behavior rather than placeholder subsystem stories.
 
-## GitHub Snapshot
-
-King is a native PHP extension for applications that need real transport,
-control-plane, and infrastructure behavior inside the runtime instead of in
-sidecars. It brings HTTP/1, HTTP/2, HTTP/3, QUIC, TLS, WebSocket, object
-storage, MCP, orchestration, telemetry, autoscaling, and Smart DNS into one
-coherent systems-grade surface for PHP. The project is still alpha, but the
-core runtime is real and the repo is driven by contract tests for transport,
-storage, recovery, and distributed operating paths. If you do not have a
-Hetzner account yet, it is time to fix that. Use the
+If you do not have a Hetzner account yet, it is time to fix that. Use the
 [Hetzner Cloud referral link](https://hetzner.cloud/?ref=VYfKUSIni63u) and you
 help support the live infrastructure tests that keep King honest.
+
+## How To Install And Run It
+
+For a repository-local build:
+
+```bash
+git clone --recurse-submodules https://github.com/Intelligent-Intern/king.git
+cd king
+./infra/scripts/build-profile.sh release
+php -d extension="$(pwd)/extension/modules/king.so" -r 'echo king_version(), PHP_EOL;'
+```
+
+That gives you the extension plus the matching QUIC runtime artifacts for the
+local release profile. If you only want the extension build, use
+[`./infra/scripts/build-extension.sh`](./infra/scripts/build-extension.sh).
+
+King is also being wired for the first honest
+[PIE](https://github.com/php/pie) install path. The maintainer workflow lives in
+[`documentation/pie-install.md`](./documentation/pie-install.md), and the
+packaged alpha target is `pie install intelligent-intern/king-ext` once the
+release asset is published.
+
+## Small But Oho
+
+One good first King application is this:
+
+- clients subscribe over WebSocket to `/watch?bucket=inbox`
+- an uploader sends `POST /upload?bucket=inbox&object=demo.txt`
+- the application stores the file in the object store
+- every subscriber for that bucket immediately gets a realtime notification
+
+The event looks like this:
+
+```json
+{
+  "event": "object.available",
+  "bucket": "inbox",
+  "object_id": "demo.txt",
+  "content_type": "text/plain",
+  "size": 1234
+}
+```
+
+The important point is that the durable write and the realtime fanout happen in
+the same native runtime. The object lands in King storage, and the same PHP
+process can immediately push the event over live WebSocket handles without
+handing the work to a sidecar or an external glue service.
+
+The bucket-subscription registry in this example is intentionally
+application-managed and process-local. King already gives you the real object
+store and WebSocket runtime needed for it, but it does not currently claim a
+built-in distributed bucket-watch API. For the same reason, this README example
+stays single-node on purpose instead of pretending the current router or
+load-balancer control-plane layer is already a verified WebSocket forwarding
+dataplane.
+
+The core shape looks like this:
+
+```php
+<?php
+
+$subscribers = [];
+
+function king_demo_bucket_from_request(array $request): string
+{
+    $query = [];
+    parse_str((string) parse_url($request['uri'] ?? '/', PHP_URL_QUERY), $query);
+
+    return (string) ($query['bucket'] ?? 'inbox');
+}
+
+function king_demo_object_from_request(array $request): string
+{
+    $query = [];
+    parse_str((string) parse_url($request['uri'] ?? '/', PHP_URL_QUERY), $query);
+
+    return (string) ($query['object'] ?? 'upload.bin');
+}
+
+function king_demo_publish(array &$subscribers, string $bucket, array $event): void
+{
+    $payload = json_encode($event, JSON_UNESCAPED_SLASHES);
+
+    foreach ($subscribers[$bucket] ?? [] as $index => $websocket) {
+        if (!is_resource($websocket) || !king_websocket_send($websocket, $payload)) {
+            unset($subscribers[$bucket][$index]);
+        }
+    }
+}
+
+king_object_store_init([
+    'primary_backend' => 'local_fs',
+    'storage_root_path' => __DIR__ . '/storage',
+    'max_storage_size_bytes' => 50 * 1024 * 1024,
+]);
+
+$watchHandler = static function (array $request) use (&$subscribers): array {
+    $bucket = king_demo_bucket_from_request($request);
+    $websocket = king_server_upgrade_to_websocket($request['session'], $request['stream_id']);
+
+    if (!is_resource($websocket)) {
+        return ['status' => 400, 'body' => 'websocket upgrade failed'];
+    }
+
+    $subscribers[$bucket][] = $websocket;
+    king_websocket_send($websocket, json_encode([
+        'event' => 'subscribed',
+        'bucket' => $bucket,
+    ], JSON_UNESCAPED_SLASHES));
+
+    return ['status' => 101, 'headers' => [], 'body' => ''];
+};
+
+$uploadHandler = static function (array $request) use (&$subscribers): array {
+    $bucket = king_demo_bucket_from_request($request);
+    $objectId = king_demo_object_from_request($request);
+    $storageKey = $bucket . '/' . $objectId;
+
+    $source = fopen('php://temp', 'r+');
+    fwrite($source, (string) ($request['body'] ?? ''));
+    rewind($source);
+
+    king_object_store_put_from_stream($storageKey, $source, [
+        'content_type' => 'text/plain',
+    ]);
+
+    king_demo_publish($subscribers, $bucket, [
+        'event' => 'object.available',
+        'bucket' => $bucket,
+        'object_id' => $objectId,
+        'content_type' => 'text/plain',
+        'size' => strlen((string) ($request['body'] ?? '')),
+    ]);
+
+    return [
+        'status' => 202,
+        'headers' => ['content-type' => 'application/json'],
+        'body' => json_encode([
+            'stored' => true,
+            'key' => $storageKey,
+        ], JSON_UNESCAPED_SLASHES),
+    ];
+};
+```
 
 King brings the following into one extension:
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "intelligent-intern/king-ext",
+    "description": "King native PHP extension packaged for PIE",
+    "type": "php-ext",
+    "license": "MIT",
+    "homepage": "https://github.com/Intelligent-Intern/king",
+    "support": {
+        "source": "https://github.com/Intelligent-Intern/king",
+        "issues": "https://github.com/Intelligent-Intern/king/issues"
+    },
+    "require": {
+        "php": ">=8.1",
+        "lib-curl": "*"
+    },
+    "php-ext": {
+        "extension-name": "king",
+        "build-path": "extension",
+        "download-url-method": "pre-packaged-source",
+        "support-zts": false,
+        "support-nts": true,
+        "os-families-exclude": [
+            "windows"
+        ]
+    }
+}

--- a/documentation/pie-install.md
+++ b/documentation/pie-install.md
@@ -1,0 +1,56 @@
+# PIE Install
+
+King can be prepared for installation through
+[PIE](https://github.com/php/pie), the PHP Installer for Extensions.
+
+The current King package shape for PIE is intentionally honest:
+
+- PIE should build King from a pre-packaged source asset, not from the default
+  repository ZIP, because King needs the bundled `quiche/` tree during build.
+- the build still compiles the bundled QUIC runtime with Cargo and Rust as part
+  of `make`
+- the install path must keep `king.so`, `libquiche.so`, and `quiche-server`
+  together under the PHP extension directory
+
+## Maintainer Steps
+
+1. Generate the PIE source asset:
+
+```bash
+./infra/scripts/package-pie-source.sh
+```
+
+This creates:
+
+```text
+dist/php_king-<version>-src.tgz
+```
+
+2. Publish a GitHub release for the matching King version tag.
+
+3. Upload the generated `php_king-<version>-src.tgz` asset to that release.
+
+4. Submit the repository to Packagist using the root `composer.json`.
+
+## User Install Shape
+
+Once the package is on Packagist and the release contains the source asset, the
+intended install command is:
+
+```bash
+pie install intelligent-intern/king-ext
+```
+
+PIE then enters the King build path under `extension/`, runs `phpize`,
+`./configure`, `make`, and `make install`, and the King build hook compiles and
+installs the QUIC runtime artifacts beside the extension.
+
+## Host Requirements
+
+- PHP development toolchain for the target PHP version
+- `cargo`
+- `rustc`
+- libcurl development headers/libraries
+
+King currently excludes Windows from this first PIE path. The current v1 target
+is Linux source installs first, then broader packaging later.

--- a/extension/Makefile.frag
+++ b/extension/Makefile.frag
@@ -1,0 +1,42 @@
+KING_QUICHE_SOURCE_ROOT = $(srcdir)/../quiche
+KING_QUICHE_TARGET_DIR = $(builddir)/../quiche/target
+KING_QUICHE_PROFILE = release
+KING_QUICHE_LIBRARY = $(KING_QUICHE_TARGET_DIR)/$(KING_QUICHE_PROFILE)/libquiche.so
+KING_QUICHE_SERVER = $(KING_QUICHE_TARGET_DIR)/$(KING_QUICHE_PROFILE)/quiche-server
+KING_RUNTIME_INSTALL_DIR = $(INSTALL_ROOT)$(EXTENSION_DIR)/king/runtime
+
+all: king-quiche-runtime
+install: install-king-runtime
+
+king-quiche-runtime:
+	@if ! command -v cargo >/dev/null 2>&1; then \
+		echo "cargo is required to build King's bundled QUIC runtime." >&2; \
+		exit 1; \
+	fi
+	@if ! command -v rustc >/dev/null 2>&1; then \
+		echo "rustc is required to build King's bundled QUIC runtime." >&2; \
+		exit 1; \
+	fi
+	@if test ! -f "$(KING_QUICHE_SOURCE_ROOT)/quiche/Cargo.toml"; then \
+		echo "Bundled quiche sources are missing under $(KING_QUICHE_SOURCE_ROOT)." >&2; \
+		echo "Use the PIE pre-packaged source asset or a checkout with the bundled QUIC tree present." >&2; \
+		exit 1; \
+	fi
+	@echo "Building King QUIC runtime artifacts"
+	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" cargo build \
+		--manifest-path "$(KING_QUICHE_SOURCE_ROOT)/quiche/Cargo.toml" \
+		--package quiche \
+		--release \
+		--locked \
+		--features ffi
+	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" cargo build \
+		--manifest-path "$(KING_QUICHE_SOURCE_ROOT)/apps/Cargo.toml" \
+		--release \
+		--locked \
+		--bin quiche-server
+
+install-king-runtime: king-quiche-runtime
+	@$(mkinstalldirs) $(KING_RUNTIME_INSTALL_DIR)
+	@echo "Installing King runtime artifacts: $(KING_RUNTIME_INSTALL_DIR)/"
+	@$(INSTALL_DATA) "$(KING_QUICHE_LIBRARY)" "$(KING_RUNTIME_INSTALL_DIR)/libquiche.so"
+	@$(INSTALL) -m 755 "$(KING_QUICHE_SERVER)" "$(KING_RUNTIME_INSTALL_DIR)/quiche-server"

--- a/extension/config.m4
+++ b/extension/config.m4
@@ -24,7 +24,8 @@ dnl =========================================================================
 
 PHP_ARG_ENABLE([king],
     [whether to enable King support],
-    [AS_HELP_STRING([--enable-king], [Enable King extension])])
+    [AS_HELP_STRING([--enable-king], [Enable King extension])],
+    [yes])
 
 PHP_ARG_WITH([king-quiche],
     [optional quiche include/library root for extended transport builds],
@@ -33,6 +34,16 @@ PHP_ARG_WITH([king-quiche],
     [no])
 
 if test "$PHP_KING" != "no"; then
+    AC_PATH_PROG([CARGO], [cargo], [no])
+    AC_PATH_PROG([RUSTC], [rustc], [no])
+
+    if test "$CARGO" = "no"; then
+        AC_MSG_ERROR([King requires cargo to build the bundled QUIC runtime.])
+    fi
+
+    if test "$RUSTC" = "no"; then
+        AC_MSG_ERROR([King requires rustc to build the bundled QUIC runtime.])
+    fi
 
     if test "$PHP_KING_QUICHE" != "no"; then
         AC_MSG_CHECKING([for optional quiche build paths])
@@ -287,6 +298,7 @@ if test "$PHP_KING" != "no"; then
     "
 
     PHP_NEW_EXTENSION([king], [$KING_SRC], [$ext_shared])
+    PHP_ADD_MAKEFILE_FRAGMENT
     PHP_SUBST([KING_SHARED_LIBADD])
 
     dnl Signal to php_king.h that we are in runtime mode.

--- a/extension/src/client/http3.c
+++ b/extension/src/client/http3.c
@@ -783,10 +783,49 @@ static void king_http3_close_runtime_handle(void)
     }
 }
 
+static zend_result king_http3_build_module_relative_candidate(
+    char *buffer,
+    size_t buffer_size,
+    const char *relative_path)
+{
+    Dl_info info;
+    const char *last_sep;
+    size_t dir_len;
+    size_t relative_len;
+
+    if (dladdr((void *) king_http3_build_module_relative_candidate, &info) == 0
+        || info.dli_fname == NULL
+        || info.dli_fname[0] == '\0') {
+        return FAILURE;
+    }
+
+    last_sep = strrchr(info.dli_fname, '/');
+    if (last_sep == NULL) {
+        return FAILURE;
+    }
+
+    dir_len = (size_t) (last_sep - info.dli_fname);
+    relative_len = strlen(relative_path);
+
+    if (dir_len + 1 + relative_len + 1 > buffer_size) {
+        return FAILURE;
+    }
+
+    memcpy(buffer, info.dli_fname, dir_len);
+    buffer[dir_len] = '/';
+    memcpy(buffer + dir_len + 1, relative_path, relative_len + 1);
+
+    return SUCCESS;
+}
+
 static zend_result king_http3_ensure_quiche_ready(void)
 {
     const char *env_path = getenv("KING_QUICHE_LIBRARY");
-    const char *const candidates[] = {
+    char module_runtime_candidate[PATH_MAX];
+    char module_local_candidate[PATH_MAX];
+    const char *candidates[] = {
+        NULL,
+        NULL,
         NULL,
         "../quiche/target/release/libquiche.so",
         "../quiche/target/debug/libquiche.so",
@@ -809,6 +848,22 @@ static zend_result king_http3_ensure_quiche_ready(void)
 
     if (env_path != NULL && env_path[0] != '\0') {
         king_http3_quiche.handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
+    }
+
+    if (king_http3_build_module_relative_candidate(
+            module_runtime_candidate,
+            sizeof(module_runtime_candidate),
+            "king/runtime/libquiche.so"
+        ) == SUCCESS) {
+        candidates[1] = module_runtime_candidate;
+    }
+
+    if (king_http3_build_module_relative_candidate(
+            module_local_candidate,
+            sizeof(module_local_candidate),
+            "libquiche.so"
+        ) == SUCCESS) {
+        candidates[2] = module_local_candidate;
     }
 
     for (i = 1; king_http3_quiche.handle == NULL && candidates[i] != NULL; ++i) {

--- a/extension/src/server/http3.c
+++ b/extension/src/server/http3.c
@@ -323,10 +323,49 @@ static void king_server_http3_close_runtime_handle(void)
     }
 }
 
+static zend_result king_server_http3_build_module_relative_candidate(
+    char *buffer,
+    size_t buffer_size,
+    const char *relative_path)
+{
+    Dl_info info;
+    const char *last_sep;
+    size_t dir_len;
+    size_t relative_len;
+
+    if (dladdr((void *) king_server_http3_build_module_relative_candidate, &info) == 0
+        || info.dli_fname == NULL
+        || info.dli_fname[0] == '\0') {
+        return FAILURE;
+    }
+
+    last_sep = strrchr(info.dli_fname, '/');
+    if (last_sep == NULL) {
+        return FAILURE;
+    }
+
+    dir_len = (size_t) (last_sep - info.dli_fname);
+    relative_len = strlen(relative_path);
+
+    if (dir_len + 1 + relative_len + 1 > buffer_size) {
+        return FAILURE;
+    }
+
+    memcpy(buffer, info.dli_fname, dir_len);
+    buffer[dir_len] = '/';
+    memcpy(buffer + dir_len + 1, relative_path, relative_len + 1);
+
+    return SUCCESS;
+}
+
 static zend_result king_server_http3_ensure_quiche_ready(void)
 {
     const char *env_path = getenv("KING_QUICHE_LIBRARY");
-    const char *const candidates[] = {
+    char module_runtime_candidate[PATH_MAX];
+    char module_local_candidate[PATH_MAX];
+    const char *candidates[] = {
+        NULL,
+        NULL,
         NULL,
         "../quiche/target/release/libquiche.so",
         "../quiche/target/debug/libquiche.so",
@@ -349,6 +388,22 @@ static zend_result king_server_http3_ensure_quiche_ready(void)
 
     if (env_path != NULL && env_path[0] != '\0') {
         king_server_http3_quiche.handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
+    }
+
+    if (king_server_http3_build_module_relative_candidate(
+            module_runtime_candidate,
+            sizeof(module_runtime_candidate),
+            "king/runtime/libquiche.so"
+        ) == SUCCESS) {
+        candidates[1] = module_runtime_candidate;
+    }
+
+    if (king_server_http3_build_module_relative_candidate(
+            module_local_candidate,
+            sizeof(module_local_candidate),
+            "libquiche.so"
+        ) == SUCCESS) {
+        candidates[2] = module_local_candidate;
     }
 
     for (i = 1; king_server_http3_quiche.handle == NULL && candidates[i] != NULL; ++i) {

--- a/extension/tests/http3_abort_client.rs
+++ b/extension/tests/http3_abort_client.rs
@@ -102,7 +102,7 @@ fn run() -> Result<(), String> {
     let mut request_sent = false;
     let mut request_stream_id = 0_u64;
     let mut request_sent_at: Option<Instant> = None;
-    let mut close_sent = false;
+    let close_sent = false;
     let close_delay = Duration::from_millis(delay_ms);
 
     let authority = match url.port() {

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: ./infra/scripts/package-pie-source.sh [--output-dir DIR]
+
+Creates the PIE pre-packaged source asset:
+  dist/php_king-<version>-src.tgz
+
+The archive contains the King source tree plus the bundled quiche checkout so
+PIE can build the extension from source with `build-path = extension`.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OUTPUT_DIR="${ROOT_DIR}/dist"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "Missing value for --output-dir." >&2
+                exit 1
+            fi
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+resolve_version() {
+    sed -n 's/^#  define PHP_KING_VERSION[[:space:]]*"\(.*\)"/\1/p' \
+        "${ROOT_DIR}/extension/include/php_king.h" | head -n 1
+}
+
+resolve_source_epoch() {
+    git -C "${ROOT_DIR}" show -s --format=%ct HEAD 2>/dev/null || printf '%s\n' "0"
+}
+
+VERSION="$(resolve_version)"
+if [[ -z "${VERSION}" ]]; then
+    echo "Failed to resolve PHP_KING_VERSION." >&2
+    exit 1
+fi
+
+if [[ -d "${ROOT_DIR}/quiche/.git" ]]; then
+    "${ROOT_DIR}/infra/scripts/bootstrap-quiche.sh" --verify-current
+fi
+
+for required in \
+    "${ROOT_DIR}/composer.json" \
+    "${ROOT_DIR}/extension/config.m4" \
+    "${ROOT_DIR}/extension/Makefile.frag" \
+    "${ROOT_DIR}/quiche/quiche/Cargo.toml" \
+    "${ROOT_DIR}/quiche/apps/Cargo.toml"; do
+    if [[ ! -e "${required}" ]]; then
+        echo "Missing required PIE source-package input: ${required}" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "${OUTPUT_DIR}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+STAGE_ROOT="${TMP_DIR}/king-${VERSION}-src"
+ARCHIVE_NAME="php_king-${VERSION}-src.tgz"
+ARCHIVE_PATH="${OUTPUT_DIR}/${ARCHIVE_NAME}"
+SOURCE_DATE_EPOCH="$(resolve_source_epoch)"
+
+mkdir -p "${STAGE_ROOT}"
+
+tar \
+    --exclude-vcs \
+    --exclude='./dist' \
+    --exclude='./compat-artifacts' \
+    --exclude='./extension/build' \
+    --exclude='./extension/modules' \
+    --exclude='./extension/Makefile' \
+    --exclude='./extension/config.cache' \
+    --exclude='./extension/config.log' \
+    --exclude='./extension/config.status' \
+    --exclude='./quiche/target' \
+    --exclude='./demo/video-chat/node_modules' \
+    -C "${ROOT_DIR}" \
+    -cf - . | tar -C "${STAGE_ROOT}" -xf -
+
+tar \
+    --sort=name \
+    --mtime="@${SOURCE_DATE_EPOCH}" \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    -C "${TMP_DIR}" \
+    -czf "${ARCHIVE_PATH}" \
+    "king-${VERSION}-src"
+
+echo "Created PIE source package: ${ARCHIVE_PATH}"

--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -16,6 +16,9 @@ php -l infra/scripts/runtime-config-compatibility.php
 php -l infra/scripts/runtime-install-smoke.php
 php -l infra/scripts/runtime-persistence-migration.php
 
+echo "Validating Composer metadata..."
+composer validate composer.json
+
 echo "Checking shell-script syntax..."
 bash -n benchmarks/run-canonical.sh
 for script in infra/scripts/*.sh; do


### PR DESCRIPTION
## What changed

This adds the first honest PIE install surface for King.

- adds a root `composer.json` with `type = php-ext` and `build-path = extension`
- adds `extension/Makefile.frag` so `make` and `make install` also build and install the bundled QUIC runtime artifacts
- adds a PIE source-package script at `./infra/scripts/package-pie-source.sh`
- teaches the HTTP/3 client and server runtimes to find `libquiche.so` relative to the installed extension directory
- documents the maintainer workflow in `documentation/pie-install.md`
- validates the new Composer metadata in `./infra/scripts/static-checks.sh`

## Why

King is not a plain `king.so` extension. The active runtime also needs the bundled QUIC artifacts, so a nominal PIE integration would still leave HTTP/3 broken after install.

This PR makes the first Linux-first source-install path honest: a PIE-compatible source package can build King from `extension/` and install `king.so`, `libquiche.so`, and `quiche-server` together under the PHP extension directory.

## Impact

After merge, the repo is ready for:

- Packagist submission of the extension package metadata
- GitHub releases that attach `php_king-<version>-src.tgz`
- a first `v0.2.0-alpha` release with a real PIE install path

## Validation

- `composer validate composer.json`
- `./infra/scripts/static-checks.sh`
- built `dist/php_king-1.0.0-src.tgz` via `./infra/scripts/package-pie-source.sh`
- unpacked that source asset and ran `phpize && ./configure && make && make install`
- verified the install result contains:
  - `king.so`
  - `king/runtime/libquiche.so`
  - `king/runtime/quiche-server`
- verified installed `king.so` finds the installed `libquiche.so` without `KING_QUICHE_LIBRARY` set by entering the HTTP/3 runtime path successfully
