### PR TITLE
[codex] Prepare v0.2.1-alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,14 @@ That gives you the extension plus the matching QUIC runtime artifacts for the
 local release profile. If you only want the extension build, use
 [`./infra/scripts/build-extension.sh`](./infra/scripts/build-extension.sh).
 
+If you want the beginner path from zero to a local WebSocket roundtrip, start
+with [documentation/getting-started.md](./documentation/getting-started.md).
+
 King is also being wired for the first honest
 [PIE](https://github.com/php/pie) install path. The maintainer workflow lives in
-[`documentation/pie-install.md`](./documentation/pie-install.md), and the
-packaged alpha target is `pie install intelligent-intern/king-ext` once the
-release asset is published.
+[`documentation/pie-install.md`](./documentation/pie-install.md). PIE is the
+successor to PECL, and the packaged alpha target is
+`pie install intelligent-intern/king-ext` once the release asset is published.
 
 ## Small But Oho
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -14,6 +14,50 @@ library. It is a native runtime that lets PHP code work with transport,
 streaming, storage, control-plane traffic, orchestration, and operations
 through one extension.
 
+## Fastest First Success
+
+If you want the shortest path from zero to "King is loaded on this machine",
+start with a local repository build:
+
+```bash
+git clone --recurse-submodules https://github.com/Intelligent-Intern/king.git
+cd king
+./infra/scripts/build-profile.sh release
+php -d extension="$(pwd)/extension/modules/king.so" -r 'echo king_version(), PHP_EOL;'
+```
+
+If that prints a version string, King is alive in your local PHP runtime.
+
+This is the easiest path today because it does not depend on package metadata,
+system-wide extension registration, or external package publication. It builds
+the extension and the matching QUIC runtime artifacts from the repository you
+already have in front of you.
+
+## What PIE Is
+
+If you keep seeing "PIE" and wondering what that means, here is the short
+version:
+
+- PIE means `PHP Installer for Extensions`
+- it is the successor to PECL
+- Composer installs PHP packages into a project
+- PIE installs PHP extensions into a PHP runtime
+
+If you already know the older PHP world, this is the translation:
+
+- PECL is the old name most extension-install tutorials still mention
+- PIE is the newer installer direction you should map that knowledge onto
+- so if an older guide says "install the extension with PECL", the modern
+  King-shaped question is "what is the PIE install path?"
+
+That matters because King is not a normal Composer library. It is an extension.
+So the long-term packaging direction is PIE, not "drop some PHP files into
+vendor and hope the runtime changes itself".
+
+The King-specific PIE details live in [PIE Install](./pie-install.md). For a
+first local success, the repository build path above is still the shortest
+route.
+
 If that sounds large, the good news is that the basic idea is still simple.
 Your PHP code decides what should happen. King owns the runtime machinery that
 makes it happen and reports back what happened.
@@ -56,6 +100,17 @@ status, headers, and body access in one object.
 `King\CancelToken` is an explicit stop signal that belongs to the caller. If an
 operation must be interruptible by your own program logic, a cancel token is
 the usual tool.
+
+King exposes these ideas in two programming styles:
+
+- a direct procedural API such as `king_send_request()` or
+  `king_client_websocket_connect()`
+- an object-oriented API such as `King\Config`, `King\Client\Http3Client`, or
+  `King\WebSocket\Connection`
+
+Neither style is the "fake" surface. They are two real ways to drive the same
+runtime. The practical choice is about how much explicit control you want in a
+small script versus how much structure you want in a larger application.
 
 You do not need to memorize all of this before writing your first program. The
 important part is to understand what kind of system King wants you to build.
@@ -136,6 +191,11 @@ to structure your program, not about two different implementations. A small
 script may prefer the procedural API. A larger application may prefer long-lived
 objects. The contract stays the same underneath.
 
+For the first local WebSocket roundtrip below, the guide intentionally uses the
+procedural API. That is the most complete beginner path today because the
+current receive loop and the on-wire server-side upgrade leaf are both exposed
+there most directly.
+
 ## What You Should Know Early
 
 New readers often ask whether King is a framework. It is not. It is a native
@@ -157,6 +217,103 @@ Another common question is whether they need to understand every subsystem
 before using the extension. They do not. The handbook is structured so you can
 start with the piece you need. The value of the early chapters is that they
 teach the common language shared by the later ones.
+
+## First Local WebSocket Roundtrip
+
+The fastest honest "King is really doing something live" demo is a local
+WebSocket roundtrip over the current on-wire HTTP/1 one-shot upgrade path.
+
+Create `server.php`:
+
+```php
+<?php
+
+king_http1_server_listen_once('127.0.0.1', 9501, null, static function (array $request): array {
+    if (($request['path'] ?? '/') !== '/chat') {
+        return [
+            'status' => 404,
+            'headers' => ['content-type' => 'text/plain'],
+            'body' => "not found\n",
+        ];
+    }
+
+    $websocket = king_server_upgrade_to_websocket($request['session'], $request['stream_id']);
+    if (!is_resource($websocket)) {
+        return [
+            'status' => 400,
+            'headers' => ['content-type' => 'text/plain'],
+            'body' => "upgrade failed\n",
+        ];
+    }
+
+    $incoming = king_client_websocket_receive($websocket, 1000);
+
+    king_websocket_send($websocket, json_encode([
+        'ok' => true,
+        'received' => $incoming,
+        'path' => $request['uri'],
+    ], JSON_UNESCAPED_SLASHES));
+
+    king_client_websocket_close($websocket, 1000, 'done');
+
+    return [
+        'status' => 101,
+        'headers' => [],
+        'body' => '',
+    ];
+});
+```
+
+Create `client.php`:
+
+```php
+<?php
+
+$websocket = king_client_websocket_connect('ws://127.0.0.1:9501/chat');
+king_client_websocket_send($websocket, 'hello-from-php');
+echo king_client_websocket_receive($websocket, 1000), PHP_EOL;
+king_client_websocket_close($websocket, 1000, 'bye');
+```
+
+Open terminal 1 and start the server:
+
+```bash
+php -d extension="$(pwd)/extension/modules/king.so" server.php
+```
+
+Open terminal 2 and run the client:
+
+```bash
+php -d extension="$(pwd)/extension/modules/king.so" client.php
+```
+
+You should see JSON come back from the server, roughly like this:
+
+```json
+{"ok":true,"received":"hello-from-php","path":"/chat"}
+```
+
+That is already a real proof point:
+
+- the server bound a real TCP listener
+- the client performed a real WebSocket handshake
+- the server upgraded the HTTP request into a live channel
+- one side sent a frame
+- the other side read it and answered
+
+The listener used here is intentionally one-shot. That makes it the smallest
+real on-wire WebSocket path in King today and keeps the first successful demo
+easy to reason about.
+
+## What To Build Right After That
+
+Once the local WebSocket roundtrip works, the next step that feels most "King"
+is usually one of these:
+
+- add `King\Config` so transport and runtime policy stop living in ad hoc arrays
+- switch from a pure chat frame to an object-store backed notification flow
+- encode your message payloads with IIBIN instead of JSON
+- start attaching telemetry so you can see the live channel behavior
 
 ## Where To Go Next
 

--- a/documentation/pie-install.md
+++ b/documentation/pie-install.md
@@ -1,16 +1,119 @@
 # PIE Install
 
-King can be prepared for installation through
-[PIE](https://github.com/php/pie), the PHP Installer for Extensions.
+King can be installed through [PIE](https://github.com/php/pie), the PHP
+Installer for Extensions.
 
-The current King package shape for PIE is intentionally honest:
+## What PIE Is
 
-- PIE should build King from a pre-packaged source asset, not from the default
-  repository ZIP, because King needs the bundled `quiche/` tree during build.
-- the build still compiles the bundled QUIC runtime with Cargo and Rust as part
-  of `make`
-- the install path must keep `king.so`, `libquiche.so`, and `quiche-server`
-  together under the PHP extension directory
+PIE is the official installer for PHP extensions and the successor to PECL.
+It is distributed as a PHAR and behaves more like Composer than like the old
+PECL flow: you run PIE as a tool, and it installs compiled PHP extensions into
+your PHP installation.
+
+If you are new to PHP extensions, the shortest mental model is this:
+
+- PECL was the older extension-distribution and install path many PHP users
+  still remember
+- PIE is the newer path you should think about first now
+- old blog posts may still tell you to run `pecl install ...`
+- for King, the packaging direction is PIE, not a fresh PECL story
+
+The official PIE README is here:
+
+- <https://github.com/php/pie>
+
+The important idea for King users is simple:
+
+- Composer installs PHP packages into a project
+- PIE installs PHP extensions into a PHP runtime
+- King is an extension, so PIE is the right packaging direction
+
+## How To Get PIE
+
+According to the official PIE docs, the current shape is:
+
+1. Download `pie.phar` from the latest PIE release.
+2. Optionally verify it with:
+
+```bash
+gh attestation verify --owner php pie.phar
+```
+
+3. Run it either as:
+
+```bash
+php pie.phar <command>
+```
+
+or move it into your `PATH`, for example:
+
+```bash
+chmod +x pie.phar
+sudo mv pie.phar /usr/local/bin/pie
+pie --help
+```
+
+PIE itself currently needs PHP `8.1` or newer to run, but it can target other
+installed PHP versions.
+
+## What King Expects From PIE
+
+King is not only `king.so`. The active runtime also needs the bundled QUIC
+artifacts. That means the honest PIE package shape for King must do all of this
+in one install:
+
+- build the extension from `extension/`
+- compile the bundled QUIC runtime with Cargo and Rust
+- install `king.so`
+- install `libquiche.so`
+- install `quiche-server`
+
+This is why King uses a pre-packaged source asset instead of pretending that
+the default repository ZIP is enough.
+
+This is also why a casual "just publish it to PECL" answer would be too loose.
+King needs the extension and the runtime artifacts to travel together, so the
+installer story has to be explicit and honest.
+
+## User Install Shape
+
+Once the package is on Packagist and the matching GitHub release contains the
+PIE source asset, the intended install command is:
+
+```bash
+pie install intelligent-intern/king-ext
+```
+
+PIE then enters the King build path under `extension/`, runs `phpize`,
+`./configure`, `make`, and `make install`, and the King build hook compiles and
+installs the QUIC runtime artifacts beside the extension.
+
+Depending on the target PHP installation and how PIE configures it, you may
+also need to enable the extension explicitly in `php.ini`:
+
+```ini
+extension=king.so
+```
+
+If PIE already reports that the extension is enabled and loaded for the target
+PHP binary, you are done.
+
+## Host Requirements
+
+For the current King alpha path, assume a Linux source install and make sure
+the host has:
+
+- PHP development toolchain for the target PHP version
+- `phpize`
+- `autoconf`
+- `make`
+- a C compiler
+- `cargo`
+- `rustc`
+- libcurl development headers and libraries
+
+King currently excludes Windows from this first PIE path. The current v1 target
+is Linux source installs first, then broader packaging later.
 
 ## Maintainer Steps
 
@@ -31,26 +134,3 @@ dist/php_king-<version>-src.tgz
 3. Upload the generated `php_king-<version>-src.tgz` asset to that release.
 
 4. Submit the repository to Packagist using the root `composer.json`.
-
-## User Install Shape
-
-Once the package is on Packagist and the release contains the source asset, the
-intended install command is:
-
-```bash
-pie install intelligent-intern/king-ext
-```
-
-PIE then enters the King build path under `extension/`, runs `phpize`,
-`./configure`, `make`, and `make install`, and the King build hook compiles and
-installs the QUIC runtime artifacts beside the extension.
-
-## Host Requirements
-
-- PHP development toolchain for the target PHP version
-- `cargo`
-- `rustc`
-- libcurl development headers/libraries
-
-King currently excludes Windows from this first PIE path. The current v1 target
-is Linux source installs first, then broader packaging later.

--- a/extension/include/php_king.h
+++ b/extension/include/php_king.h
@@ -29,7 +29,7 @@
  * Extension Version and Global Constants
  */
 #ifndef PHP_KING_VERSION
-#  define PHP_KING_VERSION      "1.0.0"
+#  define PHP_KING_VERSION      "0.2.1-alpha"
 #endif
 
 #ifndef KING_MAX_TICKET_SIZE

--- a/extension/src/integration/system_integration.c
+++ b/extension/src/integration/system_integration.c
@@ -318,22 +318,22 @@ int king_system_init_all_components(king_system_config_t *config)
     }
 
     /* Register core components */
-    king_system_register_component(KING_COMPONENT_CONFIG, "config", "1.0.0");
-    king_system_register_component(KING_COMPONENT_CLIENT, "client", "1.0.0");
-    king_system_register_component(KING_COMPONENT_SERVER, "server", "1.0.0");
+    king_system_register_component(KING_COMPONENT_CONFIG, "config", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_CLIENT, "client", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_SERVER, "server", "0.2.1-alpha");
     king_system_register_component(
         KING_COMPONENT_ROUTER_LOADBALANCER,
         "router_loadbalancer",
-        "1.0.0"
+        "0.2.1-alpha"
     );
-    king_system_register_component(KING_COMPONENT_MCP, "mcp", "1.0.0");
-    king_system_register_component(KING_COMPONENT_TELEMETRY, "telemetry", "1.0.0");
-    king_system_register_component(KING_COMPONENT_AUTOSCALING, "autoscaling", "1.0.0");
-    king_system_register_component(KING_COMPONENT_PIPELINE_ORCHESTRATOR, "orchestrator", "1.0.0");
-    king_system_register_component(KING_COMPONENT_OBJECT_STORE, "object_store", "1.0.0");
-    king_system_register_component(KING_COMPONENT_CDN, "cdn", "1.0.0");
-    king_system_register_component(KING_COMPONENT_IIBIN, "iibin", "1.0.0");
-    king_system_register_component(KING_COMPONENT_SEMANTIC_DNS, "semantic_dns", "1.0.0");
+    king_system_register_component(KING_COMPONENT_MCP, "mcp", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_TELEMETRY, "telemetry", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_AUTOSCALING, "autoscaling", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_PIPELINE_ORCHESTRATOR, "orchestrator", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_OBJECT_STORE, "object_store", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_CDN, "cdn", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_IIBIN, "iibin", "0.2.1-alpha");
+    king_system_register_component(KING_COMPONENT_SEMANTIC_DNS, "semantic_dns", "0.2.1-alpha");
 
     return SUCCESS;
 }

--- a/extension/tests/001-load-and-core.phpt
+++ b/extension/tests/001-load-and-core.phpt
@@ -15,14 +15,14 @@ var_dump($health);
 bool(true)
 bool(true)
 bool(true)
-string(5) "1.0.0"
+string(11) "0.2.1-alpha"
 array(8) {
   ["status"]=>
   string(2) "ok"
   ["build"]=>
   string(2) "v1"
   ["version"]=>
-  string(5) "1.0.0"
+  string(11) "0.2.1-alpha"
   ["config_override_allowed"]=>
   bool(false)
   ["active_runtime_count"]=>

--- a/extension/tests/006-health-shape.phpt
+++ b/extension/tests/006-health-shape.phpt
@@ -42,7 +42,7 @@ array(10) {
 }
 string(2) "ok"
 string(2) "v1"
-string(5) "1.0.0"
+string(11) "0.2.1-alpha"
 bool(true)
 bool(true)
 bool(true)

--- a/extension/tests/010-system-status.phpt
+++ b/extension/tests/010-system-status.phpt
@@ -38,7 +38,7 @@ array(4) {
 }
 bool(true)
 string(2) "v1"
-string(5) "1.0.0"
+string(11) "0.2.1-alpha"
 bool(false)
 array(6) {
   [0]=>


### PR DESCRIPTION
## What changed

This prepares the real `v0.2.1-alpha` release after the earlier accidental `v0.2.0-alpha` publish drift.

- bumps the shipped extension version and component inventory to `0.2.1-alpha`
- updates the version-sensitive PHPT expectations
- refreshes the README install section
- expands the beginner docs so new users can understand what PIE is, how it replaces old PECL thinking, and how to get from zero to a local WebSocket roundtrip

## Why

The previous alpha release was cut before the internal runtime version was bumped. That left the public tag and the shipped `king_version()`/component metadata out of sync.

This PR fixes that and also makes the release docs more honest for first-time users.

## Validation

- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/001-load-and-core.phpt tests/006-health-shape.phpt tests/010-system-status.phpt`
- `git diff --check`
