### PR TITLE
v0.2.4-alpha: AI finding cleanup and HTTP/3 abort-client fix

### DIFF
--- a/benchmarks/run.php
+++ b/benchmarks/run.php
@@ -252,13 +252,11 @@ function build_case_definitions(): array
 
                 return [
                     'run' => static function (int $iteration): int {
-                        // In this benchmark, the service identifier and display name are intentionally identical.
                         $serviceId = 'api-bench';
-                        $serviceName = 'api-bench';
 
                         if (!king_semantic_dns_register_service([
                             'service_id' => $serviceId,
-                            'service_name' => $serviceName,
+                            'service_name' => $serviceId,
                             'service_type' => 'pipeline_orchestrator',
                             'status' => 'healthy',
                             'hostname' => 'api.internal',
@@ -270,7 +268,7 @@ function build_case_definitions(): array
                         }
 
                         $discovery = king_semantic_dns_discover_service('pipeline_orchestrator');
-                        $route = king_semantic_dns_get_optimal_route($serviceName, [
+                        $route = king_semantic_dns_get_optimal_route($serviceId, [
                             'location' => [
                                 'latitude' => 52.52 + (($iteration % 100) / 1000),
                                 'longitude' => 13.405 + (($iteration % 100) / 1000),
@@ -294,7 +292,7 @@ function build_case_definitions(): array
                             + (int) ($topology['statistics']['healthy_services'] ?? 0)
                             + strlen($serviceId);
                     },
-                    'cleanup' => static function () use ($stateDir, $config): void {
+                    'cleanup' => static function () use ($stateDir): void {
                         delete_flat_directory($stateDir);
                     },
                 ];

--- a/extension/src/object_store/internal/cloud_gcs_runtime/config_and_url.inc
+++ b/extension/src/object_store/internal/cloud_gcs_runtime/config_and_url.inc
@@ -148,7 +148,6 @@ static zend_result king_object_store_gcs_build_url(
         }
 
         smart_str_free(url);
-        smart_str_appends(url, "");
         smart_str_appendl(url, config->endpoint, (size_t) (scheme_sep - config->endpoint + 3));
         smart_str_appends(url, config->bucket);
         smart_str_appendc(url, '.');
@@ -166,4 +165,3 @@ static zend_result king_object_store_gcs_build_url(
     smart_str_0(url);
     return SUCCESS;
 }
-

--- a/extension/src/object_store/internal/cloud_s3_runtime/url_and_error_mapping.inc
+++ b/extension/src/object_store/internal/cloud_s3_runtime/url_and_error_mapping.inc
@@ -1,3 +1,10 @@
+/*
+ * Percent-encode a single URL path component and append it to a smart_str.
+ *
+ * This helper performs RFC 3986-style percent-encoding suitable for path
+ * components. Unreserved characters stay unchanged, while every other byte is
+ * emitted as uppercase `%HH`. A NULL input is treated as an empty string.
+ */
 static void king_object_store_url_encode_component(
     smart_str *encoded,
     const char *value)
@@ -54,7 +61,6 @@ static zend_result king_object_store_s3_build_url(
         }
 
         smart_str_free(url);
-        smart_str_appends(url, "");
         smart_str_appendl(url, config->endpoint, (size_t) (scheme_sep - config->endpoint + 3));
         smart_str_appends(url, config->bucket);
         smart_str_appendc(url, '.');
@@ -331,4 +337,3 @@ static void king_object_store_s3_format_transport_error(
             return;
     }
 }
-

--- a/extension/tests/010-system-status.phpt
+++ b/extension/tests/010-system-status.phpt
@@ -25,7 +25,7 @@ $status = king_system_get_status();
 var_dump($status['initialized']);
 var_dump($status['component_count']);
 ?>
---EXPECT--
+--EXPECTF--
 array(4) {
   [0]=>
   string(15) "overall_healthy"
@@ -38,7 +38,7 @@ array(4) {
 }
 bool(true)
 bool(true)
-string(11) "0.2.1-alpha"
+string(%d) "%s"
 bool(false)
 array(6) {
   [0]=>

--- a/extension/tests/http3_abort_client.rs
+++ b/extension/tests/http3_abort_client.rs
@@ -209,7 +209,7 @@ fn run() -> Result<(), String> {
 
         flush_egress(&mut socket, &mut conn, &mut out)?;
 
-        if request_sent && !close_sent && request_sent_at.unwrap().elapsed() >= close_delay {
+        if request_sent && request_sent_at.unwrap().elapsed() >= close_delay {
             conn.close(true, 0x100, b"client abort")
                 .map_err(|err| format!("failed to close client QUIC connection: {err:?}"))?;
             flush_egress(&mut socket, &mut conn, &mut out)?;

--- a/extension/tests/semantic_dns_multi_host_client.inc
+++ b/extension/tests/semantic_dns_multi_host_client.inc
@@ -26,6 +26,15 @@ if (!function_exists('king_semantic_dns_wire_query')) {
     }
 }
 
+if (!function_exists('king_semantic_dns_wire_parse_response')) {
+    function king_semantic_dns_wire_parse_response($response)
+    {
+        throw new RuntimeException(
+            'king_semantic_dns_wire_parse_response is not available in this context.'
+        );
+    }
+}
+
 if ($argc < 5) {
     fwrite(
         STDERR,
@@ -46,16 +55,31 @@ try {
     $capture['service_name'] = $serviceName;
 
     $response = king_semantic_dns_wire_query($host, $port, $serviceName);
+    if (!is_array($response)
+        || !array_key_exists('timed_out', $response)
+        || !array_key_exists('response', $response)) {
+        throw new RuntimeException(
+            'Malformed response from king_semantic_dns_wire_query: missing expected keys.'
+        );
+    }
+
     $capture['timed_out'] = $response['timed_out'];
     $capture['parsed'] = king_semantic_dns_wire_parse_response($response['response']);
 } catch (Throwable $e) {
     $capture['exception_class'] = get_class($e);
     $capture['exception_message'] = $e->getMessage();
 } finally {
-    file_put_contents(
+    $bytesWritten = file_put_contents(
         $capturePath,
         json_encode($capture, JSON_PRETTY_PRINT | JSON_INVALID_UTF8_SUBSTITUTE)
     );
+    if ($bytesWritten === false) {
+        fwrite(
+            STDERR,
+            "Failed to write capture data to '{$capturePath}'.\n"
+        );
+        exit(2);
+    }
 }
 
 exit(isset($capture['exception_class']) ? 1 : 0);


### PR DESCRIPTION
## What changed
This follow-up PR only carries the two remaining fixes on top of `main` for the `v0.2.4-alpha` release line.

- address the remaining AI-quality findings in benchmark and helper paths
- document the S3 URL-encoding helper and remove redundant `smart_str` empty appends in S3/GCS URL builders
- make the system-status contract version expectation dynamic instead of hardcoding a release string
- harden the Semantic-DNS multi-host helper with response-shape validation and checked capture writes
- fix the `king-http3-abort-client` Rust helper after the upstream autofix removed a variable declaration but left the dead reference behind

## Why
The branch had been squashed/merged previously and then drifted against `main`, so I rebuilt it as a minimal follow-up delta. The result is a clean `main + 2 commits` PR instead of reopening the older release wave history.

## Impact
These are release hygiene and test-helper correctness fixes. They do not widen product surface, but they remove stale quality findings and keep the HTTP/3 abort helper compiling again.

## Validation
- `git diff --check`
- `php -l benchmarks/run.php`
- `php -l extension/tests/semantic_dns_multi_host_client.inc`
- `./infra/scripts/test-extension.sh tests/010-system-status.phpt tests/403-object-store-cloud-s3-contract.phpt tests/421-object-store-cloud-gcs-contract.phpt tests/564-semantic-dns-distributed-registration-topology-contract.phpt`
