### PR TITLE
Fix remaining AI findings in URL builders and static checks

### DIFF
--- a/extension/src/object_store/internal/cloud_gcs_runtime/config_and_url.inc
+++ b/extension/src/object_store/internal/cloud_gcs_runtime/config_and_url.inc
@@ -131,9 +131,8 @@ static zend_result king_object_store_gcs_build_url(
         return FAILURE;
     }
 
-    smart_str_appends(url, config->endpoint);
-
     if (config->path_style) {
+        smart_str_appends(url, config->endpoint);
         smart_str_appendc(url, '/');
         smart_str_appends(url, config->bucket);
         if (object_id != NULL && object_id[0] != '\0') {
@@ -147,7 +146,6 @@ static zend_result king_object_store_gcs_build_url(
             return FAILURE;
         }
 
-        smart_str_free(url);
         smart_str_appendl(url, config->endpoint, (size_t) (scheme_sep - config->endpoint + 3));
         smart_str_appends(url, config->bucket);
         smart_str_appendc(url, '.');

--- a/extension/src/object_store/internal/cloud_s3_runtime/url_and_error_mapping.inc
+++ b/extension/src/object_store/internal/cloud_s3_runtime/url_and_error_mapping.inc
@@ -44,9 +44,8 @@ static zend_result king_object_store_s3_build_url(
         return FAILURE;
     }
 
-    smart_str_appends(url, config->endpoint);
-
     if (config->path_style) {
+        smart_str_appends(url, config->endpoint);
         smart_str_appendc(url, '/');
         smart_str_appends(url, config->bucket);
         if (object_id != NULL && object_id[0] != '\0') {
@@ -60,7 +59,6 @@ static zend_result king_object_store_s3_build_url(
             return FAILURE;
         }
 
-        smart_str_free(url);
         smart_str_appendl(url, config->endpoint, (size_t) (scheme_sep - config->endpoint + 3));
         smart_str_appends(url, config->bucket);
         smart_str_appendc(url, '.');

--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -23,7 +23,7 @@ php -l infra/scripts/runtime-install-smoke.php
 php -l infra/scripts/runtime-persistence-migration.php
 
 echo "Validating Composer metadata..."
-composer validate composer.json
+composer validate "${ROOT_DIR}/composer.json"
 
 echo "Checking shell-script syntax..."
 bash -n benchmarks/run-canonical.sh
@@ -33,7 +33,7 @@ done
 
 echo "Checking GitHub Actions workflow syntax..."
 for workflow in .github/workflows/*.yml; do
-    ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' "${workflow}"
+    ruby -e 'require "yaml"; YAML.safe_load_file(ARGV[0], permitted_classes: [], permitted_symbols: [], aliases: true)' "${workflow}"
 done
 
 echo "Checking extension include layout..."


### PR DESCRIPTION
## What changed
This follow-up fixes the remaining AI-quality findings left after the previous `v0.2.4-alpha` merge.

- remove the unsafe `smart_str_free()` then append pattern from the S3 and GCS URL builders
- make `infra/scripts/static-checks.sh` validate Composer metadata through an explicit `${ROOT_DIR}/composer.json` path
- switch workflow YAML parsing in static checks from `YAML.load_file` to `YAML.safe_load_file`

## Why
These were the last reported quality findings on the remaining follow-up branch. The URL-builder change also removes an unnecessary reset pattern entirely instead of trying to mutate `smart_str` internals after free.

## Validation
- `./infra/scripts/static-checks.sh`
- `./infra/scripts/build-extension.sh`
- `./infra/scripts/test-extension.sh tests/403-object-store-cloud-s3-contract.phpt tests/421-object-store-cloud-gcs-contract.phpt`
