### PR TITLE
Fix remaining HTTP/3 and CDN AI findings

### DIFF
--- a/documentation/object-store-and-cdn.md
+++ b/documentation/object-store-and-cdn.md
@@ -405,6 +405,10 @@ the local `smart_cdn` registry is backfilled when the runtime still has honest
 metadata for that object. If the origin request times out or otherwise fails,
 King only serves stale bytes when a previous successful full read already
 retained that body; a metadata-only warm entry still fails honestly.
+Oversized origin responses do not bypass that honesty through the streaming
+path: `king_object_store_get_to_stream()` applies the same object-store body
+guard before the temp sink keeps growing, so an origin cannot spill unbounded
+bytes to local disk through CDN readthrough.
 
 That same honesty rule now applies to edge-node inventory. A bare
 `cdn_config.edge_node_count` no longer manufactures `edge-0`, `edge-1`, and so

--- a/extension/src/client/http3/quiche_loader.inc
+++ b/extension/src/client/http3/quiche_loader.inc
@@ -73,9 +73,6 @@ static zend_result king_http3_ensure_quiche_ready(void)
     char module_runtime_candidate[PATH_MAX];
     char module_local_candidate[PATH_MAX];
     const char *candidates[] = {
-        NULL,
-        NULL,
-        NULL,
         "../quiche/target/release/libquiche.so",
         "../quiche/target/debug/libquiche.so",
         "../../quiche/target/release/libquiche.so",
@@ -99,23 +96,26 @@ static zend_result king_http3_ensure_quiche_ready(void)
         king_http3_quiche.handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
     }
 
-    if (king_http3_build_module_relative_candidate(
+    /* Optional module-relative candidates must not suppress the fixed fallbacks. */
+    if (king_http3_quiche.handle == NULL
+        && king_http3_build_module_relative_candidate(
             module_runtime_candidate,
             sizeof(module_runtime_candidate),
             "king/runtime/libquiche.so"
         ) == SUCCESS) {
-        candidates[1] = module_runtime_candidate;
+        king_http3_quiche.handle = dlopen(module_runtime_candidate, RTLD_LAZY | RTLD_LOCAL);
     }
 
-    if (king_http3_build_module_relative_candidate(
+    if (king_http3_quiche.handle == NULL
+        && king_http3_build_module_relative_candidate(
             module_local_candidate,
             sizeof(module_local_candidate),
             "libquiche.so"
         ) == SUCCESS) {
-        candidates[2] = module_local_candidate;
+        king_http3_quiche.handle = dlopen(module_local_candidate, RTLD_LAZY | RTLD_LOCAL);
     }
 
-    for (i = 1; king_http3_quiche.handle == NULL && candidates[i] != NULL; ++i) {
+    for (i = 0; king_http3_quiche.handle == NULL && candidates[i] != NULL; ++i) {
         king_http3_quiche.handle = dlopen(candidates[i], RTLD_LAZY | RTLD_LOCAL);
     }
 

--- a/extension/src/object_store/internal/object_store_origin_http.inc
+++ b/extension/src/object_store/internal/object_store_origin_http.inc
@@ -1,7 +1,13 @@
 /*
  * CDN HTTP-origin readthrough helper. This keeps full-object origin fallback
- * honest with one bounded GET attempt and without replaying hidden retries.
+ * honest with one bounded GET attempt, one bounded response body, and without
+ * replaying hidden retries.
  */
+
+typedef struct _king_object_store_cdn_origin_http_stream_sink_t {
+    king_object_store_http_response_t *response;
+    FILE *stream;
+} king_object_store_cdn_origin_http_stream_sink_t;
 
 static const char *king_object_store_cdn_origin_http_effective_endpoint(void)
 {
@@ -115,6 +121,33 @@ static void king_object_store_cdn_origin_http_format_transport_error(
     );
 }
 
+static size_t king_object_store_cdn_origin_http_stream_write_callback(
+    char *contents,
+    size_t size,
+    size_t nmemb,
+    void *userdata
+)
+{
+    king_object_store_cdn_origin_http_stream_sink_t *sink =
+        (king_object_store_cdn_origin_http_stream_sink_t *) userdata;
+    size_t bytes = size * nmemb;
+    size_t written;
+
+    if (sink == NULL || sink->response == NULL || sink->stream == NULL) {
+        return 0;
+    }
+
+    if (sink->response->body_bytes + bytes > KING_OBJECT_STORE_HTTP_MAX_BODY_BYTES) {
+        sink->response->body_limit_exceeded = 1;
+        return 0;
+    }
+
+    written = fwrite(contents, 1, bytes, sink->stream);
+    sink->response->body_bytes += written;
+
+    return written;
+}
+
 static int king_object_store_cdn_origin_http_request(
     const char *object_id,
     king_object_store_http_response_t *response,
@@ -126,6 +159,7 @@ static int king_object_store_cdn_origin_http_request(
     CURL *easy = NULL;
     struct curl_slist *headers = NULL;
     smart_str url = {0};
+    king_object_store_cdn_origin_http_stream_sink_t stream_sink = {0};
     CURLcode curl_code;
     long timeout_ms;
 
@@ -161,7 +195,14 @@ static int king_object_store_cdn_origin_http_request(
     king_object_store_libcurl.curl_easy_setopt_fn(easy, CURLOPT_HTTPHEADER, headers);
     king_object_store_libcurl.curl_easy_setopt_fn(easy, CURLOPT_HTTPGET, 1L);
     if (response_body_sink != NULL) {
-        king_object_store_libcurl.curl_easy_setopt_fn(easy, CURLOPT_WRITEDATA, response_body_sink);
+        stream_sink.response = response;
+        stream_sink.stream = response_body_sink;
+        king_object_store_libcurl.curl_easy_setopt_fn(
+            easy,
+            CURLOPT_WRITEFUNCTION,
+            king_object_store_cdn_origin_http_stream_write_callback
+        );
+        king_object_store_libcurl.curl_easy_setopt_fn(easy, CURLOPT_WRITEDATA, &stream_sink);
     } else {
         king_object_store_libcurl.curl_easy_setopt_fn(easy, CURLOPT_WRITEFUNCTION, king_object_store_http_write_callback);
         king_object_store_libcurl.curl_easy_setopt_fn(easy, CURLOPT_WRITEDATA, response);
@@ -298,13 +339,13 @@ int king_object_store_cdn_origin_http_read_to_stream(
     }
 
     if (king_object_store_create_temp_file_path(temp_path, sizeof(temp_path)) != SUCCESS) {
-        snprintf(error, error_size, "Failed to allocate a bounded-memory sink for the CDN HTTP origin read.");
+        snprintf(error, error_size, "Failed to allocate a bounded local sink for the CDN HTTP origin read.");
         return FAILURE;
     }
 
     destination_fp = fopen(temp_path, "w+b");
     if (destination_fp == NULL) {
-        snprintf(error, error_size, "Failed to open the bounded-memory sink for the CDN HTTP origin read.");
+        snprintf(error, error_size, "Failed to open the bounded local sink for the CDN HTTP origin read.");
         return FAILURE;
     }
 

--- a/extension/src/server/http3/quiche_loader.inc
+++ b/extension/src/server/http3/quiche_loader.inc
@@ -68,9 +68,6 @@ static zend_result king_server_http3_ensure_quiche_ready(void)
     char module_runtime_candidate[PATH_MAX];
     char module_local_candidate[PATH_MAX];
     const char *candidates[] = {
-        NULL,
-        NULL,
-        NULL,
         "../quiche/target/release/libquiche.so",
         "../quiche/target/debug/libquiche.so",
         "../../quiche/target/release/libquiche.so",
@@ -94,23 +91,26 @@ static zend_result king_server_http3_ensure_quiche_ready(void)
         king_server_http3_quiche.handle = dlopen(env_path, RTLD_LAZY | RTLD_LOCAL);
     }
 
-    if (king_server_http3_build_module_relative_candidate(
+    /* Optional module-relative candidates must not suppress the fixed fallbacks. */
+    if (king_server_http3_quiche.handle == NULL
+        && king_server_http3_build_module_relative_candidate(
             module_runtime_candidate,
             sizeof(module_runtime_candidate),
             "king/runtime/libquiche.so"
         ) == SUCCESS) {
-        candidates[1] = module_runtime_candidate;
+        king_server_http3_quiche.handle = dlopen(module_runtime_candidate, RTLD_LAZY | RTLD_LOCAL);
     }
 
-    if (king_server_http3_build_module_relative_candidate(
+    if (king_server_http3_quiche.handle == NULL
+        && king_server_http3_build_module_relative_candidate(
             module_local_candidate,
             sizeof(module_local_candidate),
             "libquiche.so"
         ) == SUCCESS) {
-        candidates[2] = module_local_candidate;
+        king_server_http3_quiche.handle = dlopen(module_local_candidate, RTLD_LAZY | RTLD_LOCAL);
     }
 
-    for (i = 1; king_server_http3_quiche.handle == NULL && candidates[i] != NULL; ++i) {
+    for (i = 0; king_server_http3_quiche.handle == NULL && candidates[i] != NULL; ++i) {
         king_server_http3_quiche.handle = dlopen(candidates[i], RTLD_LAZY | RTLD_LOCAL);
     }
 
@@ -180,4 +180,3 @@ static zend_result king_server_http3_ensure_quiche_ready(void)
     king_server_http3_quiche.ready = true;
     return SUCCESS;
 }
-

--- a/extension/tests/565-cdn-origin-stream-size-guard-contract.phpt
+++ b/extension/tests/565-cdn-origin-stream-size-guard-contract.phpt
@@ -1,0 +1,115 @@
+--TEST--
+King CDN HTTP origin readthrough keeps the streaming path under the object-store body size guard
+--SKIPIF--
+<?php
+if (!function_exists('proc_open') || !function_exists('stream_socket_server')) {
+    echo "skip proc_open and stream_socket_server are required";
+}
+?>
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+require __DIR__ . '/cdn_origin_http_test_helper.inc';
+
+function king_cdn_origin_565_cleanup_tree(string $path): void
+{
+    if ($path === '' || !file_exists($path)) {
+        return;
+    }
+
+    if (is_dir($path) && !is_link($path)) {
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            king_cdn_origin_565_cleanup_tree($path . '/' . $entry);
+        }
+
+        @chmod($path, 0700);
+        @rmdir($path);
+        return;
+    }
+
+    @chmod($path, 0600);
+    @unlink($path);
+}
+
+$root = sys_get_temp_dir() . '/king_cdn_origin_565_' . getmypid();
+$objectId = 'oversized-stream-doc';
+$originPath = '/origin/' . rawurlencode($objectId);
+$oversizedBytes = (16 * 1024 * 1024) + 1;
+$capture = [];
+
+king_cdn_origin_565_cleanup_tree($root);
+mkdir($root, 0700, true);
+
+$server = king_cdn_origin_http_test_start_server([
+    [
+        'path' => $originPath,
+        'status' => 200,
+        'body_size' => $oversizedBytes,
+        'body_byte' => 'z',
+    ],
+]);
+
+try {
+    var_dump(king_object_store_init([
+        'storage_root_path' => $root,
+        'primary_backend' => 'local_fs',
+        'cdn_config' => [
+            'enabled' => true,
+            'default_ttl_seconds' => 90,
+            'cache_size_mb' => 64,
+            'origin_http_endpoint' => $server['endpoint'] . '/origin',
+            'origin_request_timeout_ms' => 5000,
+        ],
+    ]));
+
+    var_dump(king_object_store_put($objectId, 'seed', [
+        'content_type' => 'text/plain',
+        'object_type' => 'cache_entry',
+        'cache_policy' => 'smart_cdn',
+    ]));
+    @unlink($root . '/' . $objectId);
+    clearstatcache();
+
+    $stream = fopen('php://temp', 'w+');
+    try {
+        king_object_store_get_to_stream($objectId, $stream);
+        $exceptionClassMatches = false;
+        $exceptionMessageMatches = false;
+    } catch (Throwable $e) {
+        $exceptionClassMatches = get_class($e) === 'King\\SystemException';
+        $exceptionMessageMatches = str_contains(
+            $e->getMessage(),
+            'CDN HTTP origin response body exceeded the object-store size guard.'
+        );
+    }
+    rewind($stream);
+    $streamBody = stream_get_contents($stream);
+    fclose($stream);
+} finally {
+    $capture = king_cdn_origin_http_test_stop_server($server);
+    king_cdn_origin_565_cleanup_tree($root);
+}
+
+$events = $capture['events'] ?? [];
+
+var_dump($exceptionClassMatches);
+var_dump($exceptionMessageMatches);
+var_dump($streamBody);
+var_dump(count($events));
+var_dump(($events[0]['action'] ?? null) === 'response');
+var_dump(($events[0]['body_size'] ?? 0) === $oversizedBytes);
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+string(0) ""
+int(1)
+bool(true)
+bool(true)

--- a/extension/tests/cdn_origin_http_server.inc
+++ b/extension/tests/cdn_origin_http_server.inc
@@ -1,6 +1,6 @@
 <?php
 
-/* Bounded local HTTP origin harness for CDN readthrough timeout and retry proofs. */
+/* Bounded local HTTP origin harness for CDN readthrough timeout, retry, and size-guard proofs. */
 
 if ($argc < 5) {
     fwrite(STDERR, "usage: cdn_origin_http_server.inc <capture-path> <plan-path> <port> <bind-host>\n");
@@ -71,6 +71,7 @@ while (true) {
         'action' => $action,
         'status' => (int) ($entry['status'] ?? 200),
         'hang_ms' => (int) ($entry['hang_ms'] ?? 0),
+        'body_size' => isset($entry['body_size']) ? (int) $entry['body_size'] : strlen((string) ($entry['body'] ?? '')),
     ];
 
     if (isset($entry['hang_ms'])) {
@@ -81,19 +82,35 @@ while (true) {
 
     $status = (int) ($entry['status'] ?? 200);
     $body = (string) ($entry['body'] ?? '');
+    $bodySize = isset($entry['body_size']) ? (int) $entry['body_size'] : strlen($body);
+    $bodyByte = (string) ($entry['body_byte'] ?? 'x');
     $reason = match ($status) {
         200 => 'OK',
         404 => 'Not Found',
         503 => 'Service Unavailable',
         default => 'Origin Response',
     };
+    if ($bodyByte === '') {
+        $bodyByte = 'x';
+    }
+    $bodyByte = $bodyByte[0];
 
     $response = "HTTP/1.1 {$status} {$reason}\r\n"
         . "Content-Type: text/plain\r\n"
-        . "Content-Length: " . strlen($body) . "\r\n"
-        . "Connection: close\r\n\r\n"
-        . $body;
+        . "Content-Length: " . $bodySize . "\r\n"
+        . "Connection: close\r\n\r\n";
     fwrite($conn, $response);
+    if (isset($entry['body_size'])) {
+        $remaining = $bodySize;
+        while ($remaining > 0) {
+            $chunkLength = min($remaining, 8192);
+            $chunk = str_repeat($bodyByte, $chunkLength);
+            fwrite($conn, $chunk);
+            $remaining -= $chunkLength;
+        }
+    } else {
+        fwrite($conn, $body);
+    }
     fflush($conn);
     fclose($conn);
 

--- a/extension/tests/http3_abort_client.rs
+++ b/extension/tests/http3_abort_client.rs
@@ -209,12 +209,17 @@ fn run() -> Result<(), String> {
 
         flush_egress(&mut socket, &mut conn, &mut out)?;
 
-        if request_sent && request_sent_at.unwrap().elapsed() >= close_delay {
-            conn.close(true, 0x100, b"client abort")
-                .map_err(|err| format!("failed to close client QUIC connection: {err:?}"))?;
-            flush_egress(&mut socket, &mut conn, &mut out)?;
-            println!("ABORTED {}", request_stream_id);
-            return Ok(());
+        if request_sent {
+            if let Some(sent_at) = request_sent_at {
+                // The helper aborts exactly once and returns immediately after the close frame.
+                if sent_at.elapsed() >= close_delay {
+                    conn.close(true, 0x100, b"client abort")
+                        .map_err(|err| format!("failed to close client QUIC connection: {err:?}"))?;
+                    flush_egress(&mut socket, &mut conn, &mut out)?;
+                    println!("ABORTED {}", request_stream_id);
+                    return Ok(());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
This follow-up fixes the three remaining AI findings on the current mainline.

- preserve HTTP/3 libquiche fallback loading when `dladdr()` cannot resolve module-relative paths
- harden the HTTP/3 abort helper close path so the test helper cannot regress into an undefined close-state reference
- enforce the existing object-store body-size guard on CDN origin streaming readthrough, with a dedicated contract proving oversized origin bodies stop before the temp sink grows unbounded

## Root cause
Two of the regressions came from follow-up cleanup that tightened code paths without preserving the original fallback and single-shot close semantics. The CDN issue came from the FILE-sink streaming path bypassing the bounded libcurl write callback, so the normal object-store body guard never ran for origin readthrough-to-stream.

## Impact
- HTTP/3 runtime loading now still reaches build-tree and system `libquiche.so` fallbacks when module-relative discovery is unavailable.
- The HTTP/3 abort helper remains buildable and keeps its one-close execution contract explicit.
- CDN origin readthrough to stream is now bounded by the same object-store body limit as the in-memory path, preventing oversized origin responses from filling the local temp sink.

## Validation
- `./infra/scripts/build-extension.sh`
- `cargo build --manifest-path quiche/apps/Cargo.toml -p quiche_apps --release --locked --no-default-features --bin king-http3-abort-client`
- `./infra/scripts/test-extension.sh tests/558-cdn-origin-timeout-and-no-retry-contract.phpt tests/565-cdn-origin-stream-size-guard-contract.phpt`
- `git diff --check`