### PR TITLE
Fix remaining static-check and HTTP/3 AI findings

### DIFF
--- a/extension/src/client/http3/quiche_loader.inc
+++ b/extension/src/client/http3/quiche_loader.inc
@@ -1,4 +1,4 @@
-static const char *king_http3_map_curless_candidate_error(const char *path)
+static const char *king_http3_map_candidate_error(const char *path)
 {
     return path != NULL && path[0] != '\0' ? path : "unknown";
 }
@@ -124,7 +124,7 @@ static zend_result king_http3_ensure_quiche_ready(void)
             king_http3_quiche.load_error,
             sizeof(king_http3_quiche.load_error),
             "Failed to load libquiche for the active HTTP/3 runtime (checked '%s' first).",
-            king_http3_map_curless_candidate_error(env_path)
+            king_http3_map_candidate_error(env_path)
         );
         return FAILURE;
     }

--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -33,7 +33,7 @@ done
 
 echo "Checking GitHub Actions workflow syntax..."
 for workflow in .github/workflows/*.yml; do
-    ruby -e 'require "yaml"; YAML.safe_load_file(ARGV[0], permitted_classes: [], permitted_symbols: [], aliases: true)' "${workflow}"
+    ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: true)' "${workflow}"
 done
 
 echo "Checking extension include layout..."


### PR DESCRIPTION
## Summary
This follow-up fixes the remaining Ruby compatibility finding in the static workflow validator.

- replace `YAML.safe_load_file(...)` with `YAML.safe_load(File.read(...), ...)` in `infra/scripts/static-checks.sh`
- keep the same safe-loading policy (`permitted_classes: []`, `permitted_symbols: []`, `aliases: true`)
- preserve the existing workflow syntax gate while avoiding `ArgumentError` on Ruby versions where `safe_load_file` does not accept keyword options

## Root cause
The previous hardening switched workflow parsing from `YAML.load_file` to `YAML.safe_load_file`, but that API shape is not stable across older Ruby runtimes. On Ruby versions before 3.1, the keyword-argument form can fail even though the equivalent `safe_load(File.read(...), ...)` path is supported.

## Impact
`infra/scripts/static-checks.sh` keeps validating GitHub Actions workflow YAML safely, but no longer depends on the newer `safe_load_file` keyword API.

## Validation
- `./infra/scripts/static-checks.sh`
- `git diff --check`