### PR TITLE
Require Composer and Ruby before static checks

### DIFF
--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -20,6 +20,12 @@ if ! command -v composer >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! command -v ruby >/dev/null 2>&1; then
+    echo "Error: Ruby is required for GitHub Actions workflow validation but was not found in PATH." >&2
+    echo "Please install Ruby or ensure it is available on your PATH, then re-run this script." >&2
+    exit 1
+fi
+
 echo "Linting PHP entry surfaces..."
 php -l stubs/king.php
 php -l benchmarks/run.php

--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -14,6 +14,12 @@ if ! command -v php >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! command -v composer >/dev/null 2>&1; then
+    echo "Error: Composer is required for static checks but was not found in PATH." >&2
+    echo "Please install Composer or ensure it is available on your PATH, then re-run this script." >&2
+    exit 1
+fi
+
 echo "Linting PHP entry surfaces..."
 php -l stubs/king.php
 php -l benchmarks/run.php


### PR DESCRIPTION
## Summary
This follow-up hardens `infra/scripts/static-checks.sh` with explicit tool prerequisite checks before the script reaches the corresponding validation steps.

- require `composer` before Composer metadata validation runs
- require `ruby` before GitHub Actions workflow YAML validation runs

## Root cause
The script already failed early for missing PHP, but the later Composer and Ruby-dependent steps still assumed those tools existed. On machines without one of them installed, the script failed with the shell's default command-not-found behavior instead of a clear action-oriented error.

## Impact
`static-checks.sh` now fails fast with clear prerequisite messages for all three external tools it depends on directly at runtime: PHP, Composer, and Ruby.

## Validation
- `./infra/scripts/static-checks.sh`
- `git diff --check`