### PR TITLE
Disable YAML aliases in static workflow checks

### DIFF
--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -45,7 +45,7 @@ done
 
 echo "Checking GitHub Actions workflow syntax..."
 for workflow in .github/workflows/*.yml; do
-    ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: true)' "${workflow}"
+    ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: false)' "${workflow}"
 done
 
 echo "Checking extension include layout..."


### PR DESCRIPTION
## Summary
This follow-up hardens the static GitHub Actions workflow validator by disabling YAML aliases during safe parsing.

- switch `YAML.safe_load(..., aliases: true)` to `YAML.safe_load(..., aliases: false)` in `infra/scripts/static-checks.sh`
- keep the existing safe-load restrictions on classes and symbols

## Root cause
The earlier safe-load hardening still permitted YAML aliases. That kept the parser more permissive than needed for local workflow syntax validation and left room for alias-expansion abuse patterns.

## Impact
`infra/scripts/static-checks.sh` still validates workflow YAML structure, but now rejects aliases instead of allowing them during the safe-load pass.

## Validation
- `./infra/scripts/static-checks.sh`
- `git diff --check`