### PR TITLE
Check workflow files before YAML safe load

### DIFF
--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -45,6 +45,10 @@ done
 
 echo "Checking GitHub Actions workflow syntax..."
 for workflow in .github/workflows/*.yml; do
+    if [ ! -r "${workflow}" ]; then
+        echo "Error: Workflow file '${workflow}' does not exist or is not readable." >&2
+        exit 1
+    fi
     ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: false)' "${workflow}"
 done
 


### PR DESCRIPTION
## Summary
This follow-up hardens the static workflow YAML validator by checking each workflow file is readable before passing it into Ruby's `File.read(...)`.

- fail early with a clear message when a workflow path is missing or unreadable
- keep the existing `YAML.safe_load(..., aliases: false)` validation path unchanged for readable files

## Root cause
The validator already iterated concrete workflow paths, but it still relied on `File.read(...)` to surface file access failures. That produced a Ruby-level exception path instead of a clear shell-level prerequisite error.

## Impact
`infra/scripts/static-checks.sh` now reports unreadable workflow files directly and exits before invoking the YAML parser on a bad path.

## Validation
- `./infra/scripts/static-checks.sh`
- `git diff --check`