### PR TITLE
Clarify workflow YAML validation failures

### DIFF
--- a/infra/scripts/static-checks.sh
+++ b/infra/scripts/static-checks.sh
@@ -44,12 +44,23 @@ for script in infra/scripts/*.sh; do
 done
 
 echo "Checking GitHub Actions workflow syntax..."
-for workflow in .github/workflows/*.yml; do
-    if [ ! -r "${workflow}" ]; then
-        echo "Error: Workflow file '${workflow}' does not exist or is not readable." >&2
-        exit 1
-    fi
-    ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], permitted_symbols: [], aliases: false)' "${workflow}"
+shopt -s nullglob
+workflow_files=(.github/workflows/*.yml)
+shopt -u nullglob
+for workflow in "${workflow_files[@]}"; do
+    ruby -e 'require "yaml";
+path = ARGV.fetch(0)
+begin
+    YAML.safe_load(
+        File.read(path),
+        permitted_classes: [],
+        permitted_symbols: [],
+        aliases: false
+    )
+rescue StandardError => error
+    STDERR.puts "Error: YAML validation failed for #{path}: #{error.class}: #{error.message}"
+    exit 1
+end' "${workflow}"
 done
 
 echo "Checking extension include layout..."


### PR DESCRIPTION
## Summary
This follow-up makes workflow YAML validation failures in `infra/scripts/static-checks.sh` explicit and user-facing instead of relying on a raw Ruby exception path.

- remove the redundant shell-level readability check in the workflow loop
- expand the workflow glob through a `nullglob` array so the loop only iterates real matches
- wrap `YAML.safe_load(...)` in a Ruby `begin`/`rescue` block that prints the workflow filename and the parser or file-read error before exiting

## Root cause
The previous follow-up added a shell readability guard, but the underlying Ruby call still surfaced YAML and file-read failures as a generic interpreter exception path. That left the actual validation error handling split awkwardly across shell and Ruby.

## Impact
`static-checks.sh` now reports workflow YAML validation failures in a single clear format:
`Error: YAML validation failed for <path>: <error-class>: <message>`

## Validation
- `./infra/scripts/static-checks.sh`
- targeted negative-path smoke with intentionally invalid YAML to confirm the new error message shape
- `git diff --check`