### PR TITLE
Fix PHP 8.5 telemetry ini shutdown leaks

### DIFF
--- a/extension/src/config/config.c
+++ b/extension/src/config/config.c
@@ -105,7 +105,9 @@ void king_config_release_module_globals(void)
     KING_CONFIG_FREE_PERSISTENT(king_native_object_store_config.node_discovery_mode);
     memset(&king_native_object_store_config, 0, sizeof(king_native_object_store_config));
 
+    KING_CONFIG_FREE_PERSISTENT(king_open_telemetry_config.exporter_endpoint);
     KING_CONFIG_FREE_PERSISTENT(king_open_telemetry_config.exporter_protocol);
+    KING_CONFIG_FREE_PERSISTENT(king_open_telemetry_config.exporter_headers);
     KING_CONFIG_FREE_PERSISTENT(king_open_telemetry_config.traces_sampler_type);
     KING_CONFIG_FREE_PERSISTENT(king_open_telemetry_config.metrics_default_histogram_boundaries);
     memset(&king_open_telemetry_config, 0, sizeof(king_open_telemetry_config));


### PR DESCRIPTION
## Summary
- free the custom OpenTelemetry INI strings that survive normal ini unregister
- leave standard INI-managed strings on the engine-owned shutdown path
- stop the PHP 8.5 leak-sanitizer soak from aborting during module startup/shutdown

## Verification
- ./infra/scripts/build-extension.sh
- php -n -d extension=/home/jochen/projects/king.site/king/extension/modules/king.so -m
- phpdbg -qrr -n -d extension=/home/jochen/projects/king.site/king/extension/modules/king.so /tmp/king-startup-check.php
- repeated php startup/shutdown loop x10