### PR TITLE
fix: align PIE source asset naming with release tag

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -242,7 +242,7 @@ jobs:
           submodules: recursive
 
       - name: Build PIE source package
-        run: ./infra/scripts/package-pie-source.sh --output-dir release-assets
+        run: ./infra/scripts/package-pie-source.sh --output-dir release-assets --release-tag "${{ needs.resolve-release-merge.outputs.release-tag }}"
 
       - name: Upload PIE source asset
         uses: actions/upload-artifact@v4
@@ -388,7 +388,6 @@ jobs:
               release-assets/*
           else
             gh release create "${RELEASE_TAG}" \
-              --repo "${GITHUB_REPOSITORY}" \
               --title "King ${RELEASE_TAG}" \
               --target "${RELEASE_TARGET}" \
               --notes-from-tag \

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: ./infra/scripts/package-pie-source.sh [--output-dir DIR]
+Usage: ./infra/scripts/package-pie-source.sh [--output-dir DIR] [--release-tag TAG]
 
 Creates the PIE pre-packaged source asset:
   dist/php_king-<version>-src.tgz
@@ -17,6 +17,7 @@ EOF
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 OUTPUT_DIR="${ROOT_DIR}/dist"
+RELEASE_TAG="${KING_PIE_RELEASE_TAG:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -26,6 +27,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --release-tag)
+            if [[ $# -lt 2 ]]; then
+                echo "Missing value for --release-tag." >&2
+                exit 1
+            fi
+            RELEASE_TAG="$2"
             shift 2
             ;;
         -h|--help)
@@ -50,6 +59,9 @@ resolve_source_epoch() {
 }
 
 VERSION="$(resolve_version)"
+if [[ -n "${RELEASE_TAG}" ]]; then
+    VERSION="${RELEASE_TAG}"
+fi
 if [[ -z "${VERSION}" ]]; then
     echo "Failed to resolve PHP_KING_VERSION." >&2
     exit 1

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -113,8 +113,10 @@ mkdir -p "${STAGE_ROOT}"
         --exclude-vcs \
         --exclude='./dist' \
         --exclude='./compat-artifacts' \
+        --exclude='./.cargo' \
         --exclude='./extension/build' \
         --exclude='./extension/quiche/target' \
+        --exclude='./extension/tests/http3_ticket_server/target' \
         --exclude='./extension/modules' \
         --exclude='./extension/Makefile' \
         --exclude='./extension/config.cache' \

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -109,14 +109,15 @@ SOURCE_DATE_EPOCH="$(resolve_source_epoch)"
 
 mkdir -p "${STAGE_ROOT}"
 
-tar \
-    --exclude-vcs \
-    --exclude='./dist' \
-    --exclude='./compat-artifacts' \
-    --exclude='./extension/build' \
-    --exclude='./extension/modules' \
-    --exclude='./extension/Makefile' \
-    --exclude='./extension/config.cache' \
+    tar \
+        --exclude-vcs \
+        --exclude='./dist' \
+        --exclude='./compat-artifacts' \
+        --exclude='./extension/build' \
+        --exclude='./extension/quiche/target' \
+        --exclude='./extension/modules' \
+        --exclude='./extension/Makefile' \
+        --exclude='./extension/config.cache' \
     --exclude='./extension/config.log' \
     --exclude='./extension/config.status' \
     --exclude='./quiche/target' \


### PR DESCRIPTION
## Why
PIE install for tag releases failed because the pre-packaged source asset was named using PHP_KING_VERSION (0.2.1-alpha) instead of the release tag (v0.2.8-alpha). PIE requires names like php_king-v<version>-src.tgz.

## Changes
- package-pie-source.sh: add --release-tag and optional KING_PIE_RELEASE_TAG override
- release-merge-publish.yml: pass release-tag into PIE source packaging step
- remove unsupported --repo flag for gh release create

## Impact
- Enables 🥧 PHP Installer for Extensions (PIE) 1.3.10, from The PHP Foundation
This command may need elevated privileges, and may prompt you for your password.
You are running PHP 8.4.15
Target PHP installation: 8.4.15 nts, on Linux/OSX/etc x86_64 (from /usr/bin/php8.4)
Found package: intelligent-intern/king-ext:v0.2.8-alpha which provides ext-king
Found prebuilt archive: https://github.com/Intelligent-Intern/king/releases/download/v0.2.8-alpha/php_king-v0.2.8-alpha-src.tgz to find release asset.
