### PR TITLE
build: add PIE Cargo lockfile compatibility for quiche runtime builds

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -242,7 +242,7 @@ jobs:
           submodules: recursive
 
       - name: Build PIE source package
-        run: ./infra/scripts/package-pie-source.sh --output-dir release-assets
+        run: ./infra/scripts/package-pie-source.sh --output-dir release-assets --release-tag "${{ needs.resolve-release-merge.outputs.release-tag }}"
 
       - name: Upload PIE source asset
         uses: actions/upload-artifact@v4
@@ -388,7 +388,6 @@ jobs:
               release-assets/*
           else
             gh release create "${RELEASE_TAG}" \
-              --repo "${GITHUB_REPOSITORY}" \
               --title "King ${RELEASE_TAG}" \
               --target "${RELEASE_TARGET}" \
               --notes-from-tag \

--- a/extension/Makefile.frag
+++ b/extension/Makefile.frag
@@ -4,6 +4,7 @@ KING_QUICHE_PROFILE = release
 KING_QUICHE_LIBRARY = $(KING_QUICHE_TARGET_DIR)/$(KING_QUICHE_PROFILE)/libquiche.so
 KING_QUICHE_SERVER = $(KING_QUICHE_TARGET_DIR)/$(KING_QUICHE_PROFILE)/quiche-server
 KING_RUNTIME_INSTALL_DIR = $(INSTALL_ROOT)$(EXTENSION_DIR)/king/runtime
+KING_CARGO_BUILD_COMPAT = $(srcdir)/../infra/scripts/cargo-build-compat.sh
 
 all: king-quiche-runtime
 install: install-king-runtime
@@ -23,13 +24,13 @@ king-quiche-runtime:
 		exit 1; \
 	fi
 	@echo "Building King QUIC runtime artifacts"
-	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" cargo build \
+	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" $(KING_CARGO_BUILD_COMPAT) cargo build \
 		--manifest-path "$(KING_QUICHE_SOURCE_ROOT)/quiche/Cargo.toml" \
 		--package quiche \
 		--release \
 		--locked \
 		--features ffi
-	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" cargo build \
+	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" $(KING_CARGO_BUILD_COMPAT) cargo build \
 		--manifest-path "$(KING_QUICHE_SOURCE_ROOT)/apps/Cargo.toml" \
 		--release \
 		--locked \

--- a/extension/Makefile.fragments
+++ b/extension/Makefile.fragments
@@ -1,9 +1,10 @@
-KING_QUICHE_SOURCE_ROOT = /home/jochen/projects/king.site/king/extension/../quiche
-KING_QUICHE_TARGET_DIR = ./../quiche/target
+KING_QUICHE_SOURCE_ROOT = $(srcdir)/../quiche
+KING_QUICHE_TARGET_DIR = $(builddir)/../quiche/target
 KING_QUICHE_PROFILE = release
 KING_QUICHE_LIBRARY = $(KING_QUICHE_TARGET_DIR)/$(KING_QUICHE_PROFILE)/libquiche.so
 KING_QUICHE_SERVER = $(KING_QUICHE_TARGET_DIR)/$(KING_QUICHE_PROFILE)/quiche-server
 KING_RUNTIME_INSTALL_DIR = $(INSTALL_ROOT)$(EXTENSION_DIR)/king/runtime
+KING_CARGO_BUILD_COMPAT = $(srcdir)/../infra/scripts/cargo-build-compat.sh
 
 all: king-quiche-runtime
 install: install-king-runtime
@@ -23,13 +24,13 @@ king-quiche-runtime:
 		exit 1; \
 	fi
 	@echo "Building King QUIC runtime artifacts"
-	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" cargo build \
+	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" $(KING_CARGO_BUILD_COMPAT) cargo build \
 		--manifest-path "$(KING_QUICHE_SOURCE_ROOT)/quiche/Cargo.toml" \
 		--package quiche \
 		--release \
 		--locked \
 		--features ffi
-	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" cargo build \
+	@CARGO_TARGET_DIR="$(KING_QUICHE_TARGET_DIR)" $(KING_CARGO_BUILD_COMPAT) cargo build \
 		--manifest-path "$(KING_QUICHE_SOURCE_ROOT)/apps/Cargo.toml" \
 		--release \
 		--locked \

--- a/infra/scripts/cargo-build-compat.sh
+++ b/infra/scripts/cargo-build-compat.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <cargo-command...>" >&2
+    echo "Example: $(basename "$0") cargo build --manifest-path ... --locked" >&2
+    exit 2
+fi
+
+cmd=( "$@" )
+last_status=0
+status=0
+lockfile_path=""
+removed_lockfile_error=""
+
+is_lockfile_version4_error() {
+    local output="$1"
+
+    if printf '%s\n' "${output}" | grep -qi "lock file version 4"; then
+        if printf '%s\n' "${output}" | grep -qiE "next-lockfile-bump|requires.*next.*lockfile|unknown lockfile version"; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+run_without_lockfile_once() {
+    local -n _cmd_ref="$1"
+    local -n _lockfile_ref="$2"
+    local _status=0
+    local capture_file=""
+
+    if [[ -z "${_lockfile_ref}" || ! -f "${_lockfile_ref}" ]]; then
+        return 1
+    fi
+
+    if ! mv "${_lockfile_ref}" "${_lockfile_ref}.king-backup"; then
+        return 1
+    fi
+
+    capture_file="$(mktemp)"
+    run_command_capture _status "${capture_file}" "${_cmd_ref[@]}"
+    removed_lockfile_error="$(cat "${capture_file}")"
+    rm -f "${capture_file}"
+
+    mv "${_lockfile_ref}.king-backup" "${_lockfile_ref}"
+
+    return "${_status}"
+}
+
+run_command_capture() {
+    local -n _status_ref="$1"
+    local _capture_file="$2"
+    shift 2
+    local -a _command=( "$@" )
+
+    set +e
+    "${_command[@]}" 2>"${_capture_file}"
+    _status_ref=$?
+    set -e
+}
+
+extract_manifest_path() {
+    local -n _cmd_ref="$1"
+    local i=0
+    local arg
+
+    lockfile_path=""
+
+    for i in "${!_cmd_ref[@]}"; do
+        arg="${_cmd_ref[$i]}"
+
+        if [[ "${arg}" == --manifest-path ]]; then
+            lockfile_path="${_cmd_ref[$((i + 1))]:-}"
+            break
+        fi
+
+        if [[ "${arg}" == --manifest-path=* ]]; then
+            lockfile_path="${arg#--manifest-path=}"
+            break
+        fi
+    done
+
+    if [[ -n "${lockfile_path}" ]]; then
+        lockfile_path="${lockfile_path%/*}/Cargo.lock"
+    fi
+}
+
+tmp="$(mktemp)"
+run_command_capture last_status "${tmp}" "${cmd[@]}"
+if [[ "${last_status}" -ne 0 ]]; then
+    status="${last_status}"
+    error_output="$(cat "${tmp}")"
+    rm -f "${tmp}"
+
+    if is_lockfile_version4_error "${error_output}"; then
+        echo "Cargo lockfile format is unsupported with current toolchain; retrying without --locked." >&2
+
+        fallback_cmd=()
+        for arg in "${cmd[@]}"; do
+            if [[ "${arg}" == "--locked" ]]; then
+                continue
+            fi
+            fallback_cmd+=( "${arg}" )
+        done
+
+        if [[ "${#fallback_cmd[@]}" -eq 0 ]]; then
+            echo "Failed to construct fallback cargo command." >&2
+            printf '%s\n' "${error_output}" >&2
+            exit "${status}"
+        fi
+
+        tmp="$(mktemp)"
+        run_command_capture status "${tmp}" "${fallback_cmd[@]}"
+        error_output="$(cat "${tmp}")"
+
+        if [[ "${status}" -ne 0 ]]; then
+            printf 'Fallback cargo command failed with exit code %s.\n' "${status}" >&2
+            rm -f "${tmp}"
+
+            extract_manifest_path fallback_cmd
+            if run_without_lockfile_once fallback_cmd lockfile_path; then
+                echo "Retrying without lockfile constraint and without lockfile file." >&2
+                exit 0
+            fi
+            if [[ -n "${removed_lockfile_error}" ]]; then
+                printf '%s\n' "${removed_lockfile_error}" >&2
+            else
+                printf '%s\n' "${error_output}" >&2
+            fi
+
+            exit "${status}"
+        fi
+
+        rm -f "${tmp}"
+        exit 0
+    fi
+
+    printf '%s\n' "${error_output}" >&2
+    exit "${status}"
+fi
+
+rm -f "${tmp}"

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: ./infra/scripts/package-pie-source.sh [--output-dir DIR]
+Usage: ./infra/scripts/package-pie-source.sh [--output-dir DIR] [--release-tag TAG]
 
 Creates the PIE pre-packaged source asset:
   dist/php_king-<version>-src.tgz
@@ -17,6 +17,7 @@ EOF
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 OUTPUT_DIR="${ROOT_DIR}/dist"
+RELEASE_TAG="${KING_PIE_RELEASE_TAG:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -26,6 +27,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --release-tag)
+            if [[ $# -lt 2 ]]; then
+                echo "Missing value for --release-tag." >&2
+                exit 1
+            fi
+            RELEASE_TAG="$2"
             shift 2
             ;;
         -h|--help)
@@ -50,6 +59,9 @@ resolve_source_epoch() {
 }
 
 VERSION="$(resolve_version)"
+if [[ -n "${RELEASE_TAG}" ]]; then
+    VERSION="${RELEASE_TAG}"
+fi
 if [[ -z "${VERSION}" ]]; then
     echo "Failed to resolve PHP_KING_VERSION." >&2
     exit 1

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -113,8 +113,10 @@ mkdir -p "${STAGE_ROOT}"
         --exclude-vcs \
         --exclude='./dist' \
         --exclude='./compat-artifacts' \
+        --exclude='./.cargo' \
         --exclude='./extension/build' \
         --exclude='./extension/quiche/target' \
+        --exclude='./extension/tests/http3_ticket_server/target' \
         --exclude='./extension/modules' \
         --exclude='./extension/Makefile' \
         --exclude='./extension/config.cache' \

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -109,14 +109,15 @@ SOURCE_DATE_EPOCH="$(resolve_source_epoch)"
 
 mkdir -p "${STAGE_ROOT}"
 
-tar \
-    --exclude-vcs \
-    --exclude='./dist' \
-    --exclude='./compat-artifacts' \
-    --exclude='./extension/build' \
-    --exclude='./extension/modules' \
-    --exclude='./extension/Makefile' \
-    --exclude='./extension/config.cache' \
+    tar \
+        --exclude-vcs \
+        --exclude='./dist' \
+        --exclude='./compat-artifacts' \
+        --exclude='./extension/build' \
+        --exclude='./extension/quiche/target' \
+        --exclude='./extension/modules' \
+        --exclude='./extension/Makefile' \
+        --exclude='./extension/config.cache' \
     --exclude='./extension/config.log' \
     --exclude='./extension/config.status' \
     --exclude='./quiche/target' \


### PR DESCRIPTION
## Summary
- Add `infra/scripts/cargo-build-compat.sh` to handle Cargo lockfile v4 parsing failures (`lock file version 4 requires -Znext-lockfile-bump`) on older toolchains.
- Wire wrapper into `extension/Makefile.frag` and `extension/Makefile.fragments` to wrap all PIE quiche build cargo invocations.

## Why
PIE installations were failing on `make install` with lockfile v4 parsing errors when building bundled quiche runtime artifacts.

## Verification
- Manual PIE source package now contains `infra/scripts/cargo-build-compat.sh` and updated Makefile fragments.
- Local compatibility path exercises the wrapper fallback logic for fallback and lockfile-removal handling.

