### PR TITLE
security: avoid lockfile-v4 bypass in PIE compatibility wrapper

### DIFF
--- a/infra/scripts/cargo-build-compat.sh
+++ b/infra/scripts/cargo-build-compat.sh
@@ -11,8 +11,8 @@ fi
 cmd=( "$@" )
 last_status=0
 status=0
-lockfile_path=""
-removed_lockfile_error=""
+retry_status=0
+retry_output=""
 
 is_lockfile_version4_error() {
     local output="$1"
@@ -26,31 +26,50 @@ is_lockfile_version4_error() {
     return 1
 }
 
-run_without_lockfile_once() {
+run_with_nightly_lockfile_bump() {
     local -n _cmd_ref="$1"
-    local -n _lockfile_ref="$2"
-    local -n _error_ref="$3"
-    local _status=0
+    local _status_var="$2"
+    local _output_var="$3"
+    local -a command_prefix=()
+    local -a fallback_cmd=()
+    local has_next_lockfile_bump=0
     local capture_file=""
+    local tmp_status=0
+    local tmp_output=""
+    local i=0
+    local start_at=1
 
-    if [[ -z "${_lockfile_ref}" || ! -f "${_lockfile_ref}" ]]; then
+    if [[ "${_cmd_ref[0]}" != "cargo" ]]; then
         return 1
     fi
 
-    if ! mv -- "${_lockfile_ref}" "${_lockfile_ref}.king-backup"; then
-        return 1
+    if [[ "${_cmd_ref[1]:-}" == +* ]]; then
+        start_at=2
     fi
+
+    for (( i = start_at; i < ${#_cmd_ref[@]}; i++ )); do
+        if [[ "${_cmd_ref[$i]}" == "-Z" && "${_cmd_ref[$((i + 1))]:-}" == "next-lockfile-bump" ]]; then
+            has_next_lockfile_bump=1
+        fi
+    done
+
+    command_prefix=( "${_cmd_ref[0]}" "+nightly" )
+    fallback_cmd=( "${command_prefix[@]}" )
+    if [[ "${has_next_lockfile_bump}" -eq 0 ]]; then
+        fallback_cmd+=( "-Z" "next-lockfile-bump" )
+    fi
+
+    fallback_cmd+=( "${_cmd_ref[@]:start_at}" )
 
     capture_file="$(mktemp)"
-    run_command_capture _status "${capture_file}" "${_cmd_ref[@]}"
-    _error_ref="$(cat "${capture_file}")"
+    run_command_capture tmp_status "${capture_file}" "${fallback_cmd[@]}"
+    tmp_output="$(cat "${capture_file}")"
     rm -f "${capture_file}"
 
-    if ! mv -- "${_lockfile_ref}.king-backup" "${_lockfile_ref}"; then
-        return 1
-    fi
+    printf -v "${_status_var}" '%s' "${tmp_status}"
+    printf -v "${_output_var}" '%s' "${tmp_output}"
 
-    return "${_status}"
+    return "${tmp_status}"
 }
 
 run_command_capture() {
@@ -65,35 +84,6 @@ run_command_capture() {
     set -e
 }
 
-extract_manifest_path() {
-    local -n _cmd_ref="$1"
-    local i=0
-    local arg
-
-    lockfile_path=""
-
-    for i in "${!_cmd_ref[@]}"; do
-        arg="${_cmd_ref[$i]}"
-
-        if [[ "${arg}" == --manifest-path ]]; then
-            lockfile_path="${_cmd_ref[$((i + 1))]:-}"
-            break
-        fi
-
-        if [[ "${arg}" == --manifest-path=* ]]; then
-            lockfile_path="${arg#--manifest-path=}"
-            break
-        fi
-    done
-
-    if [[ -n "${lockfile_path}" ]]; then
-        lockfile_path="${lockfile_path%/*}/Cargo.lock"
-        return 0
-    fi
-
-    lockfile_path="${PWD}/Cargo.lock"
-}
-
 tmp="$(mktemp)"
 run_command_capture last_status "${tmp}" "${cmd[@]}"
 if [[ "${last_status}" -ne 0 ]]; then
@@ -102,46 +92,24 @@ if [[ "${last_status}" -ne 0 ]]; then
     rm -f "${tmp}"
 
     if is_lockfile_version4_error "${error_output}"; then
-        echo "Cargo lockfile format is unsupported with current toolchain; retrying without --locked." >&2
+        echo "Cargo lockfile format is unsupported with current toolchain; retrying with nightly lockfile-bump compatibility." >&2
 
-        fallback_cmd=()
-        for arg in "${cmd[@]}"; do
-            if [[ "${arg}" == "--locked" ]]; then
-                continue
-            fi
-            fallback_cmd+=( "${arg}" )
-        done
+        run_with_nightly_lockfile_bump cmd retry_status retry_output
+        status="${retry_status}"
 
-        if [[ "${#fallback_cmd[@]}" -eq 0 ]]; then
-            echo "Failed to construct fallback cargo command." >&2
-            printf '%s\n' "${error_output}" >&2
-            exit "${status}"
-        fi
-
-        extract_manifest_path fallback_cmd
-        if run_without_lockfile_once fallback_cmd lockfile_path removed_lockfile_error; then
-            echo "Retrying without lockfile constraint and without lockfile file." >&2
+        if [[ "${status}" -eq 0 ]]; then
             exit 0
         fi
 
-        tmp="$(mktemp)"
-        run_command_capture status "${tmp}" "${fallback_cmd[@]}"
-        error_output="$(cat "${tmp}")"
+        printf 'Fallback cargo command failed with exit code %s.\n' "${status}" >&2
+        printf '%s\n' "${retry_output}" >&2
 
-        if [[ "${status}" -ne 0 ]]; then
-            printf 'Fallback cargo command failed with exit code %s.\n' "${status}" >&2
-            rm -f "${tmp}"
-            if [[ -n "${removed_lockfile_error}" ]]; then
-                printf '%s\n' "${removed_lockfile_error}" >&2
-            else
-                printf '%s\n' "${error_output}" >&2
-            fi
-
-            exit "${status}"
-        fi
-
-        rm -f "${tmp}"
-        exit 0
+        cat <<'EOF' >&2
+This project requires a cargo toolchain that can read lockfile v4.
+Either install a modern rust toolchain (or nightly with `-Z next-lockfile-bump` support)
+or prebuild the release artifacts on a toolchain with lockfile-v4 support.
+EOF
+        exit "${status}"
     fi
 
     printf '%s\n' "${error_output}" >&2


### PR DESCRIPTION
## Summary
- Replace the previous lockfile-v4 fallback path that removed `Cargo.lock` and retried unpinned.
- Retry lockfile-v4 failures only with `cargo +nightly -Z next-lockfile-bump` while keeping `--locked` behavior.
- If the nightly path is unavailable, fail with an explicit build-toolchain guidance message.

## Why
A previous compatibility fallback could resolve dependencies without the lockfile, which weakened supply-chain integrity and was flagged as a medium security finding.

## Validation
- `bash -n infra/scripts/cargo-build-compat.sh`
- Local PoC fallback simulation for lockfile-v4 errors (compatibility path)
