### PR TITLE
Fix release artifact publish staging

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -263,6 +263,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release merge commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-release-merge.outputs.release-commit }}
+          submodules: recursive
+
       - name: Download packaged release artifacts
         uses: actions/download-artifact@v4
         with:
@@ -328,12 +334,6 @@ jobs:
         with:
           name: king-release-pie-source
           path: release-assets
-
-      - name: Checkout release merge commit
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.resolve-release-merge.outputs.release-commit }}
-          submodules: recursive
 
       - name: Verify release assets
         run: |

--- a/CONTRIBUTE
+++ b/CONTRIBUTE
@@ -18,7 +18,7 @@ Use the repository docs like this:
   Single moving roadmap and execution queue.
 - `READYNESS_TRACKER.md`
   Long-form completion tracker and closure reference.
-- `CONTRIBUTE.md`
+- `CONTRIBUTE`
   Contribution and workflow rules.
 - `stubs/king.php`
   Public PHP signature surface.
@@ -35,7 +35,7 @@ multiple docs.
 
 Use it with these rules:
 
-- read `CONTRIBUTE.md` before starting or replenishing any `20`-issue batch
+- read `CONTRIBUTE` before starting or replenishing any `20`-issue batch
 - only work items that are currently open in `ISSUES.md`
 - do not pull new items from `READYNESS_TRACKER.md` into `ISSUES.md` unless the user explicitly asks for a new `20`-issue batch
 - when the current batch is exhausted, stop and wait instead of self-refilling the queue

--- a/EPIC.md
+++ b/EPIC.md
@@ -99,7 +99,7 @@ Use the root documents like this:
   single moving roadmap and execution queue
 - `PROJECT_ASSESSMENT.md`
   verified implementation state and current caveats
-- `CONTRIBUTE.md`
+- `CONTRIBUTE`
   workflow and change discipline
 
 ## When To Change This File

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -9,7 +9,7 @@
 
 ## Working Rules
 
-- read `CONTRIBUTE.md` before starting, replenishing, or reshaping any `20`-issue batch
+- read `CONTRIBUTE` before starting, replenishing, or reshaping any `20`-issue batch
 - keep the active batch visible here until it is exhausted; mark closed leaves as `[x]` instead of deleting them mid-batch
 - every item must be narrow enough to implement and verify inside this repo
 - if a tracker item is still too broad, split it before adding it here

--- a/PROJECT_ASSESSMENT.md
+++ b/PROJECT_ASSESSMENT.md
@@ -184,7 +184,7 @@ Use the root documents like this:
   long-form completion tracker and broad closure reference
 - `PROJECT_ASSESSMENT.md`
   verified current state and caveats
-- `CONTRIBUTE.md`
+- `CONTRIBUTE`
   workflow and verification discipline
 - `stubs/king.php`
   public PHP signature surface

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ build. The maintainer workflow is documented in
 
 ## Contributing
 
-See [CONTRIBUTE.md](CONTRIBUTE.md).
+See [CONTRIBUTE](CONTRIBUTE).
 
 ## License
 

--- a/READYNESS_TRACKER.md
+++ b/READYNESS_TRACKER.md
@@ -609,7 +609,7 @@ Flow::extract($king->objectStore()->source('raw/orders/*.ndjson'))
 - [ ] Transition `PROJECT_ASSESSMENT.md` to a state with no remaining caveats
 - [ ] Empty `ISSUES.md` completely
 - [ ] Synchronize `EPIC.md` with the final end-state
-- [ ] Align `CONTRIBUTE.md` with final build / test / release process
+- [ ] Align `CONTRIBUTE` with final build / test / release process
 - [ ] Keep `stubs/king.php` permanently exact with runtime
 - [ ] Leave no public API without real runtime coverage
 - [ ] Leave no documentation containing "simulated", "local-first", "incomplete", or equivalent residual states

--- a/infra/scripts/check-php-support-matrix.sh
+++ b/infra/scripts/check-php-support-matrix.sh
@@ -22,10 +22,10 @@ require_line() {
 require_line "${ROOT_DIR}/infra/scripts/container-smoke-matrix.sh" \
     "PHP_VERSIONS_CSV=\"\${PHP_VERSIONS:-${EXPECTED_CSV}}\""
 
-require_line "${ROOT_DIR}/CONTRIBUTE.md" \
+require_line "${ROOT_DIR}/CONTRIBUTE" \
     "./infra/scripts/container-smoke-matrix.sh --php-versions ${EXPECTED_CSV}"
 
-require_line "${ROOT_DIR}/CONTRIBUTE.md" \
+require_line "${ROOT_DIR}/CONTRIBUTE" \
     "./infra/scripts/php-version-docker-matrix.sh --php-versions ${EXPECTED_CSV}"
 
 ruby - "${ROOT_DIR}" "${EXPECTED_CSV}" <<'RUBY'

--- a/infra/scripts/ensure-quiche-toolchain.sh
+++ b/infra/scripts/ensure-quiche-toolchain.sh
@@ -139,7 +139,7 @@ check_lockfile_compat() {
         return 0
     fi
 
-    if cat "${tmp_file}" | grep -qi "lock file version 4"; then
+    if grep -qi "lock file version 4" "${tmp_file}"; then
         rm -f "${tmp_file}"
         return 2
     fi

--- a/infra/scripts/package-pie-source.sh
+++ b/infra/scripts/package-pie-source.sh
@@ -109,17 +109,17 @@ SOURCE_DATE_EPOCH="$(resolve_source_epoch)"
 
 mkdir -p "${STAGE_ROOT}"
 
-    tar \
-        --exclude-vcs \
-        --exclude='./dist' \
-        --exclude='./compat-artifacts' \
-        --exclude='./.cargo' \
-        --exclude='./extension/build' \
-        --exclude='./extension/quiche/target' \
-        --exclude='./extension/tests/http3_ticket_server/target' \
-        --exclude='./extension/modules' \
-        --exclude='./extension/Makefile' \
-        --exclude='./extension/config.cache' \
+tar \
+    --exclude-vcs \
+    --exclude='./dist' \
+    --exclude='./compat-artifacts' \
+    --exclude='./.cargo' \
+    --exclude='./extension/build' \
+    --exclude='./extension/quiche/target' \
+    --exclude='./extension/tests/http3_ticket_server/target' \
+    --exclude='./extension/modules' \
+    --exclude='./extension/Makefile' \
+    --exclude='./extension/config.cache' \
     --exclude='./extension/config.log' \
     --exclude='./extension/config.status' \
     --exclude='./quiche/target' \


### PR DESCRIPTION
## Summary
- fix the `Publish release artifacts` job so downloaded assets survive long enough to be verified and uploaded
- keep the contributor guide rename from `CONTRIBUTE.md` to `CONTRIBUTE`
- update repository references and the support-matrix check script to the renamed guide path

## Root cause
- the release publish job downloaded package artifacts into `release-assets`
- it then ran `actions/checkout`, which cleaned the workspace and removed the downloaded directory
- `Verify release assets` therefore failed with `Missing release-assets staging directory.` and the GitHub release was never created

## Fix
- move `Checkout release merge commit` ahead of the artifact download steps in `.github/workflows/release-merge-publish.yml`
- leave the rest of the release publish flow unchanged

## Impact
- the merge-to-main release workflow can verify and publish the staged `v1.0.0-beta` assets instead of failing before `gh release create`
- docs and scripts now use the `CONTRIBUTE` path consistently

## Validation
- inspected the failing Actions job log for run `24110804026`, job `70345127785`
- confirmed the failure occurred in `Verify release assets` immediately after a late `actions/checkout`
- verified the workflow diff only reorders that checkout step ahead of artifact downloads