### PR TITLE
Fix release publish without local tag notes

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -396,7 +396,7 @@ jobs:
             gh release create "${RELEASE_TAG}" \
               --title "King ${RELEASE_TAG}" \
               --target "${RELEASE_TARGET}" \
-              --notes-from-tag \
+              --generate-notes \
               "${prerelease_args[@]}" \
               release-assets/*
           fi


### PR DESCRIPTION
## Summary
- fix the GitHub release creation step in `King Release Publish on Merge`
- switch the first-release path from `--notes-from-tag` to `--generate-notes`

## Root cause
- the workflow creates `v1.0.0-beta` on first publish
- `gh release create --notes-from-tag` requires the tag to already exist locally
- in run `24111244082`, job `70346528226`, the publish job failed with: `cannot generate release notes from tag v1.0.0-beta as it does not exist locally`

## Fix
- keep the existing upload path for already-existing releases
- for the initial `gh release create`, use generated release notes instead of tag-derived notes

## Impact
- the next merge of `develop/v1.0.0-beta` into `main` can create the `v1.0.0-beta` release instead of failing before publication

## Validation
- inspected the failing Actions job log for run `24111244082`, job `70346528226`
- verified the new failure happens after asset verification and during `gh release create`
- kept the diff to a single workflow-line change