### PR TITLE
Fix stale beta expectations in health PHPTs

### DIFF
--- a/extension/tests/001-load-and-core.phpt
+++ b/extension/tests/001-load-and-core.phpt
@@ -15,14 +15,14 @@ var_dump($health);
 bool(true)
 bool(true)
 bool(true)
-string(11) "0.2.1-alpha"
+string(10) "1.0.0-beta"
 array(8) {
   ["status"]=>
   string(2) "ok"
   ["build"]=>
   string(2) "v1"
   ["version"]=>
-  string(11) "0.2.1-alpha"
+  string(10) "1.0.0-beta"
   ["config_override_allowed"]=>
   bool(false)
   ["active_runtime_count"]=>

--- a/extension/tests/006-health-shape.phpt
+++ b/extension/tests/006-health-shape.phpt
@@ -42,7 +42,7 @@ array(10) {
 }
 string(2) "ok"
 string(2) "v1"
-string(11) "0.2.1-alpha"
+string(10) "1.0.0-beta"
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
## Summary
- update the stale version expectations in `extension/tests/001-load-and-core.phpt`
- update the stale version expectation in `extension/tests/006-health-shape.phpt`

## Root cause
- the extension runtime now reports `1.0.0-beta`
- both PHPTs still expected the old `0.2.1-alpha` string
- the rest of the health payload shape still matches, so the failures are expectation drift rather than runtime regressions

## Impact
- `tests/001-load-and-core.phpt` no longer fails on the version string
- `tests/006-health-shape.phpt` no longer fails on the health `version` field

## Validation
- verified the live runtime output locally with `php -n -d extension=/home/jochen/projects/king.site/king/extension/modules/king.so`
- confirmed `king_version()` returns `1.0.0-beta`
- confirmed `king_health()` still exposes the same stable field shape and runtime counts, with only the version string changed