### PR TITLE
Fix invalid release workflow condition for Docker Hub publish job

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -411,7 +411,7 @@ jobs:
       - resolve-release-merge
       - build-release-packages
       - publish-release
-    if: needs.resolve-release-merge.outputs.is-merge-to-main == 'true' && needs.resolve-release-merge.outputs.should-publish == 'true' && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+    if: needs.resolve-release-merge.outputs.is-merge-to-main == 'true' && needs.resolve-release-merge.outputs.should-publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## Summary
- fix invalid GitHub Actions expression in `release-merge-publish.yml`
- remove `secrets.*` usage from the job-level `if` expression in `dockerhub-runtime-release`
- keep existing Docker Hub secret usage in step inputs unchanged

## Why
GitHub rejected the workflow as invalid because `secrets.*` is not allowed in that job-level expression context. This restores workflow parsing so release publish jobs can run again.