### PR TITLE
fix(video-chat-smoke): avoid hard dependency on dist/docker-packages

### DIFF
--- a/demo/video-chat/backend-king-php/Dockerfile
+++ b/demo/video-chat/backend-king-php/Dockerfile
@@ -12,14 +12,22 @@ RUN apt-get update \
     && docker-php-ext-install pdo_sqlite \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=bind,source=dist/docker-packages,target=/mnt/packages,readonly \
+RUN --mount=type=bind,source=.,target=/src,readonly \
     set -eux; \
-    package_dir="/mnt/packages/php${VIDEOCHAT_BACKEND_PHP_VERSION}/linux-${TARGETARCH}"; \
-    test -d "${package_dir}"; \
-    archive="$(find "${package_dir}" -maxdepth 1 -type f -name '*.tar.gz' | head -n 1)"; \
-    test -n "${archive}"; \
     mkdir -p /opt/king; \
-    tar -xzf "${archive}" -C /opt/king --strip-components=2 --wildcards '*/modules/king.so'; \
+    package_dir="/src/dist/docker-packages/php${VIDEOCHAT_BACKEND_PHP_VERSION}/linux-${TARGETARCH}"; \
+    archive=""; \
+    if [ -d "${package_dir}" ]; then \
+        archive="$(find "${package_dir}" -maxdepth 1 -type f -name '*.tar.gz' | head -n 1 || true)"; \
+    fi; \
+    if [ -n "${archive}" ] && [ -f "${archive}" ]; then \
+        tar -xzf "${archive}" -C /opt/king --strip-components=2 --wildcards '*/modules/king.so'; \
+    elif [ -f /src/extension/modules/king.so ]; then \
+        cp /src/extension/modules/king.so /opt/king/king.so; \
+    else \
+        echo "Missing king extension artifact: expected ${package_dir}/*.tar.gz or /src/extension/modules/king.so" >&2; \
+        exit 1; \
+    fi; \
     test -f /opt/king/king.so
 
 COPY demo/video-chat/backend-king-php/ /app/


### PR DESCRIPTION
## Summary
- replace the backend image extension step mount from `source=dist/docker-packages` to `source=.`
- resolve extension artifact from either:
  - `dist/docker-packages/php<version>/linux-<arch>/*.tar.gz` (preferred), or
  - `extension/modules/king.so` (fallback)
- keep a hard failure with clear message if neither artifact exists

## Why
`demo/video-chat/scripts/smoke.sh` runs compose from environments where `dist/docker-packages` is not present. The previous Dockerfile failed during cache-key calculation before build could continue.

## Validation
- reran `VIDEOCHAT_SMOKE_COMPOSE_ONLY=1 VIDEOCHAT_SMOKE_REQUIRE_COMPOSE=1 bash demo/video-chat/scripts/smoke.sh`
- compose no longer fails at Docker build step with `/dist/docker-packages: not found`
- run then proceeds to later runtime/login checks (separate issue)
