### PR TITLE
ci: reuse PHP base image and rebuild only when stale

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -20,6 +20,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
   REGISTRY: ghcr.io
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  PHP_BASE_MAX_AGE_DAYS: "14"
 
 jobs:
   resolve-release-merge:
@@ -101,6 +102,159 @@ jobs:
           echo "release-version=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "release-tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
           echo "release-commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+
+  ensure-php-base-images:
+    name: Ensure PHP base image PHP ${{ matrix.php-version }}
+    needs:
+      - resolve-release-merge
+    if: needs.resolve-release-merge.outputs.is-merge-to-main == 'true' && needs.resolve-release-merge.outputs.should-publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
+
+    steps:
+      - name: Checkout release merge commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-release-merge.outputs.release-commit }}
+          submodules: recursive
+
+      - name: Prepare PHP base image metadata
+        id: meta-base
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY##*/}"
+          owner_lc="$(printf '%s' "${owner}" | tr '[:upper:]' '[:lower:]')"
+          repo_lc="$(printf '%s' "${repo}" | tr '[:upper:]' '[:lower:]')"
+          image="${REGISTRY}/${owner_lc}/${repo_lc}-php-base"
+          tag="php${{ matrix.php-version }}-main"
+          created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          {
+            printf 'owner=%s\n' "${owner}"
+            printf 'repo_lc=%s\n' "${repo_lc}"
+            printf 'package_name=%s\n' "${repo_lc}-php-base"
+            printf 'image=%s\n' "${image}"
+            printf 'tag=%s\n' "${tag}"
+            printf 'ref=%s:%s\n' "${image}" "${tag}"
+            printf 'created_at=%s\n' "${created_at}"
+            printf 'labels<<EOF\n'
+            printf 'org.opencontainers.image.title=king-php-base\n'
+            printf 'org.opencontainers.image.description=King shared PHP runtime base image\n'
+            printf 'org.opencontainers.image.created=%s\n' "${created_at}"
+            printf 'org.opencontainers.image.revision=%s\n' "${{ needs.resolve-release-merge.outputs.release-commit }}"
+            printf 'org.opencontainers.image.source=https://github.com/%s\n' "${GITHUB_REPOSITORY}"
+            printf 'org.opencontainers.image.version=php%s-main\n' "${{ matrix.php-version }}"
+            printf 'EOF\n'
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether base image rebuild is required
+        id: decide-base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          owner="${{ steps.meta-base.outputs.owner }}"
+          package_name="${{ steps.meta-base.outputs.package_name }}"
+          target_tag="${{ steps.meta-base.outputs.tag }}"
+          max_age_days="${PHP_BASE_MAX_AGE_DAYS}"
+          versions_json="$(mktemp)"
+          decision_file="$(mktemp)"
+
+          if gh api -H "Accept: application/vnd.github+json" "/orgs/${owner}/packages/container/${package_name}/versions?per_page=100" >"${versions_json}" 2>/dev/null; then
+            :
+          elif gh api -H "Accept: application/vnd.github+json" "/users/${owner}/packages/container/${package_name}/versions?per_page=100" >"${versions_json}" 2>/dev/null; then
+            :
+          else
+            {
+              echo "rebuild=true"
+              echo "reason=package lookup failed; forcing base rebuild"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          python3 - "${versions_json}" "${target_tag}" "${max_age_days}" >"${decision_file}" <<'PY'
+          import datetime
+          import json
+          import sys
+
+          versions_path, target_tag, max_age_days_raw = sys.argv[1:4]
+          max_age_days = int(max_age_days_raw)
+          now = datetime.datetime.now(datetime.timezone.utc)
+
+          with open(versions_path, "r", encoding="utf-8") as fh:
+              versions = json.load(fh)
+
+          tag_version = None
+          for item in versions:
+              tags = (((item.get("metadata") or {}).get("container") or {}).get("tags") or [])
+              if target_tag in tags:
+                  tag_version = item
+                  break
+
+          if tag_version is None:
+              print("rebuild=true")
+              print("reason=base image tag missing")
+              sys.exit(0)
+
+          updated_at = tag_version.get("updated_at") or tag_version.get("created_at")
+          if not isinstance(updated_at, str) or not updated_at:
+              print("rebuild=true")
+              print("reason=base image timestamp missing")
+              sys.exit(0)
+
+          timestamp = datetime.datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+          age_days = (now - timestamp).total_seconds() / 86400.0
+
+          if age_days > max_age_days:
+              print("rebuild=true")
+              print(f"reason=base image stale ({age_days:.1f}d>{max_age_days}d)")
+          else:
+              print("rebuild=false")
+              print(f"reason=base image fresh ({age_days:.1f}d<={max_age_days}d)")
+          PY
+
+          cat "${decision_file}" >> "${GITHUB_OUTPUT}"
+
+      - name: Report PHP base image decision
+        run: |
+          set -euo pipefail
+          echo "Base image: ${{ steps.meta-base.outputs.ref }}"
+          echo "Decision : rebuild=${{ steps.decide-base.outputs.rebuild }}"
+          echo "Reason   : ${{ steps.decide-base.outputs.reason }}"
+
+      - name: Build and push PHP base image
+        if: steps.decide-base.outputs.rebuild == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./infra/php-runtime-base.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-base.outputs.ref }}
+          labels: ${{ steps.meta-base.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            PHP_VERSION=${{ matrix.php-version }}
 
   build-release-packages:
     name: Build release artifacts for ${{ matrix.php-version }} / ${{ matrix.arch-label }}
@@ -628,6 +782,7 @@ jobs:
     needs:
       - resolve-release-merge
       - build-release-packages
+      - ensure-php-base-images
       - publish-release
     if: needs.resolve-release-merge.outputs.is-merge-to-main == 'true' && needs.resolve-release-merge.outputs.should-publish == 'true'
     runs-on: ubuntu-latest
@@ -658,6 +813,9 @@ jobs:
           image="intelligentintern/king"
           release_version="${{ needs.resolve-release-merge.outputs.release-version }}"
           revision="${{ needs.resolve-release-merge.outputs.release-commit }}"
+          owner_lc="$(printf '%s' "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
+          repo_lc="$(printf '%s' "${GITHUB_REPOSITORY##*/}" | tr '[:upper:]' '[:lower:]')"
+          php_base_image="${REGISTRY}/${owner_lc}/${repo_lc}-php-base:php8.5-main"
           created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
           if [[ -z "${release_version}" ]]; then
@@ -682,6 +840,7 @@ jobs:
             printf 'org.opencontainers.image.source=https://github.com/%s\n' "${GITHUB_REPOSITORY}"
             printf 'EOF\n'
             printf 'created_at=%s\n' "${created_at}"
+            printf 'php_base_image=%s\n' "${php_base_image}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
@@ -696,6 +855,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker Hub runtime image
         uses: docker/build-push-action@v7
         with:
@@ -709,6 +875,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=8.5
+            PHP_BASE_IMAGE=${{ steps.meta-dockerhub.outputs.php_base_image }}
             BUILD_DATE=${{ steps.meta-dockerhub.outputs.created_at }}
             VCS_REF=${{ needs.resolve-release-merge.outputs.release-commit }}
 
@@ -741,6 +908,7 @@ jobs:
     needs:
       - resolve-release-merge
       - build-release-packages
+      - ensure-php-base-images
     if: needs.resolve-release-merge.outputs.is-merge-to-main == 'true' && needs.resolve-release-merge.outputs.should-publish == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -789,6 +957,9 @@ jobs:
           set -euo pipefail
           image_name="$(printf '%s' "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
           image="${REGISTRY}/${image_name}"
+          owner_lc="$(printf '%s' "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
+          repo_lc="$(printf '%s' "${GITHUB_REPOSITORY##*/}" | tr '[:upper:]' '[:lower:]')"
+          php_base_image="${REGISTRY}/${owner_lc}/${repo_lc}-php-base:php${{ matrix.php-version }}-main"
           revision="${{ needs.resolve-release-merge.outputs.release-commit }}"
           short_sha="$(printf '%s' "${revision}" | cut -c1-12)"
 
@@ -814,6 +985,7 @@ jobs:
             printf 'org.opencontainers.image.source=https://github.com/%s\n' "${GITHUB_REPOSITORY}"
             printf 'EOF\n'
             printf 'created_at=%s\n' "${created_at}"
+            printf 'php_base_image=%s\n' "${php_base_image}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
@@ -842,6 +1014,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
+            PHP_BASE_IMAGE=${{ steps.meta.outputs.php_base_image }}
             BUILD_DATE=${{ steps.meta.outputs.created_at }}
             VCS_REF=${{ needs.resolve-release-merge.outputs.release-commit }}
 
@@ -850,6 +1023,7 @@ jobs:
     needs:
       - resolve-release-merge
       - build-release-packages
+      - ensure-php-base-images
     if: needs.resolve-release-merge.outputs.is-merge-to-main == 'true' && needs.resolve-release-merge.outputs.should-publish == 'true'
     runs-on: ubuntu-latest
     strategy:
@@ -893,6 +1067,9 @@ jobs:
           set -euo pipefail
           image_name="$(printf '%s' "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
           image="${REGISTRY}/${image_name}-demo"
+          owner_lc="$(printf '%s' "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
+          repo_lc="$(printf '%s' "${GITHUB_REPOSITORY##*/}" | tr '[:upper:]' '[:lower:]')"
+          php_base_image="${REGISTRY}/${owner_lc}/${repo_lc}-php-base:php${{ matrix.php-version }}-main"
           revision="${{ needs.resolve-release-merge.outputs.release-commit }}"
           short_sha="$(printf '%s' "${revision}" | cut -c1-12)"
 
@@ -918,6 +1095,7 @@ jobs:
             printf 'org.opencontainers.image.source=https://github.com/%s\n' "${GITHUB_REPOSITORY}"
             printf 'EOF\n'
             printf 'created_at=%s\n' "${created_at}"
+            printf 'php_base_image=%s\n' "${php_base_image}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Set up QEMU
@@ -946,5 +1124,6 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             PHP_VERSION=${{ matrix.php-version }}
+            PHP_BASE_IMAGE=${{ steps.meta-demo.outputs.php_base_image }}
             BUILD_DATE=${{ steps.meta-demo.outputs.created_at }}
             VCS_REF=${{ needs.resolve-release-merge.outputs.release-commit }}

--- a/demo/video-chat/backend-king-php/Dockerfile
+++ b/demo/video-chat/backend-king-php/Dockerfile
@@ -12,14 +12,22 @@ RUN apt-get update \
     && docker-php-ext-install pdo_sqlite \
     && rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=bind,source=dist/docker-packages,target=/mnt/packages,readonly \
+RUN --mount=type=bind,source=.,target=/src,readonly \
     set -eux; \
-    package_dir="/mnt/packages/php${VIDEOCHAT_BACKEND_PHP_VERSION}/linux-${TARGETARCH}"; \
-    test -d "${package_dir}"; \
-    archive="$(find "${package_dir}" -maxdepth 1 -type f -name '*.tar.gz' | head -n 1)"; \
-    test -n "${archive}"; \
     mkdir -p /opt/king; \
-    tar -xzf "${archive}" -C /opt/king --strip-components=2 --wildcards '*/modules/king.so'; \
+    package_dir="/src/dist/docker-packages/php${VIDEOCHAT_BACKEND_PHP_VERSION}/linux-${TARGETARCH}"; \
+    archive=""; \
+    if [ -d "${package_dir}" ]; then \
+        archive="$(find "${package_dir}" -maxdepth 1 -type f -name '*.tar.gz' | head -n 1 || true)"; \
+    fi; \
+    if [ -n "${archive}" ] && [ -f "${archive}" ]; then \
+        tar -xzf "${archive}" -C /opt/king --strip-components=2 --wildcards '*/modules/king.so'; \
+    elif [ -f /src/extension/modules/king.so ]; then \
+        cp /src/extension/modules/king.so /opt/king/king.so; \
+    else \
+        echo "Missing king extension artifact: expected ${package_dir}/*.tar.gz or /src/extension/modules/king.so" >&2; \
+        exit 1; \
+    fi; \
     test -f /opt/king/king.so
 
 COPY demo/video-chat/backend-king-php/ /app/

--- a/infra/demo-server/Dockerfile
+++ b/infra/demo-server/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG PHP_VERSION=8.5
+ARG PHP_BASE_IMAGE=ubuntu:24.04
 
 FROM node:22-bookworm-slim AS frontend-build
 
@@ -29,9 +30,10 @@ RUN --mount=type=bind,source=dist/docker-packages,target=/mnt/packages,readonly 
     test -n "${archive}"; \
     tar -xzf "${archive}" -C /opt/king/package --strip-components=1
 
-FROM ubuntu:24.04 AS runtime
+FROM ${PHP_BASE_IMAGE} AS runtime
 
 ARG PHP_VERSION
+ARG PHP_BASE_IMAGE
 ARG BUILD_DATE
 ARG VCS_REF
 ENV DEBIAN_FRONTEND=noninteractive
@@ -42,51 +44,52 @@ LABEL org.opencontainers.image.title="king-demo-server" \
       org.opencontainers.image.revision="${VCS_REF}"
 
 RUN set -eux; \
-    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
-      if [ -f "${source_file}" ]; then \
-        sed -i \
-          -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
-          -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
-          "${source_file}"; \
-      fi; \
-    done; \
-    apt-get \
-      -o Acquire::Retries=5 \
-      -o Acquire::http::Timeout=30 \
-      -o Acquire::https::Timeout=30 \
-      -o Acquire::ForceIPv4=true \
-      update; \
-    apt-get install -y --no-install-recommends \
-      ca-certificates \
-      curl \
-      gnupg \
-      libcurl3t64-gnutls \
-      libuuid1; \
-    rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-    mkdir -p /usr/share/keyrings; \
-    curl --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors -fsSL \
-      'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' \
-      | gpg --dearmor -o /usr/share/keyrings/ondrej-php.gpg; \
-    . /etc/os-release; \
-    printf 'deb [signed-by=/usr/share/keyrings/ondrej-php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu %s main\n' "${VERSION_CODENAME}" \
-      > /etc/apt/sources.list.d/ondrej-php.list; \
-    apt-get \
-      -o Acquire::Retries=5 \
-      -o Acquire::http::Timeout=30 \
-      -o Acquire::https::Timeout=30 \
-      -o Acquire::ForceIPv4=true \
-      update; \
-    apt-get install -y --no-install-recommends \
-      "php${PHP_VERSION}-cli" \
-      "php${PHP_VERSION}-curl" \
-      "php${PHP_VERSION}-mbstring" \
-      "php${PHP_VERSION}-sockets" \
-      "php${PHP_VERSION}-sqlite3" \
-      "php${PHP_VERSION}-xml"; \
-    ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php; \
-    rm -rf /var/lib/apt/lists/*
+    if command -v "php${PHP_VERSION}" >/dev/null 2>&1; then \
+      ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php; \
+    else \
+      for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+        if [ -f "${source_file}" ]; then \
+          sed -i \
+            -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
+            "${source_file}"; \
+        fi; \
+      done; \
+      apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        -o Acquire::ForceIPv4=true \
+        update; \
+      apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        libcurl3t64-gnutls \
+        libuuid1; \
+      mkdir -p /usr/share/keyrings; \
+      curl --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors -fsSL \
+        'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' \
+        | gpg --dearmor -o /usr/share/keyrings/ondrej-php.gpg; \
+      . /etc/os-release; \
+      printf 'deb [signed-by=/usr/share/keyrings/ondrej-php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu %s main\n' "${VERSION_CODENAME}" \
+        > /etc/apt/sources.list.d/ondrej-php.list; \
+      apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        -o Acquire::ForceIPv4=true \
+        update; \
+      apt-get install -y --no-install-recommends \
+        "php${PHP_VERSION}-cli" \
+        "php${PHP_VERSION}-curl" \
+        "php${PHP_VERSION}-mbstring" \
+        "php${PHP_VERSION}-sockets" \
+        "php${PHP_VERSION}-sqlite3" \
+        "php${PHP_VERSION}-xml"; \
+      ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 
 RUN mkdir -p /opt/king /opt/king/demo /workspace
 

--- a/infra/php-runtime-base.Dockerfile
+++ b/infra/php-runtime-base.Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.7
+
+ARG PHP_VERSION=8.5
+
+FROM ubuntu:24.04
+
+ARG PHP_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Provision only the shared Ubuntu/PHP runtime dependencies so downstream
+# runtime/demo images can reuse this layer without repeating flaky live PPA ops.
+RUN set -eux; \
+    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+      if [ -f "${source_file}" ]; then \
+        sed -i \
+          -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+          -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
+          "${source_file}"; \
+      fi; \
+    done; \
+    apt-get \
+      -o Acquire::Retries=5 \
+      -o Acquire::http::Timeout=30 \
+      -o Acquire::https::Timeout=30 \
+      -o Acquire::ForceIPv4=true \
+      update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg \
+      libcurl3t64-gnutls \
+      libuuid1; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    mkdir -p /usr/share/keyrings; \
+    curl --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors -fsSL \
+      'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' \
+      | gpg --dearmor -o /usr/share/keyrings/ondrej-php.gpg; \
+    . /etc/os-release; \
+    printf 'deb [signed-by=/usr/share/keyrings/ondrej-php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu %s main\n' "${VERSION_CODENAME}" \
+      > /etc/apt/sources.list.d/ondrej-php.list; \
+    apt-get \
+      -o Acquire::Retries=5 \
+      -o Acquire::http::Timeout=30 \
+      -o Acquire::https::Timeout=30 \
+      -o Acquire::ForceIPv4=true \
+      update; \
+    apt-get install -y --no-install-recommends \
+      "php${PHP_VERSION}-cli" \
+      "php${PHP_VERSION}-curl" \
+      "php${PHP_VERSION}-mbstring" \
+      "php${PHP_VERSION}-sockets" \
+      "php${PHP_VERSION}-sqlite3" \
+      "php${PHP_VERSION}-xml"; \
+    ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php; \
+    rm -rf /var/lib/apt/lists/*

--- a/infra/php-runtime.Dockerfile
+++ b/infra/php-runtime.Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG PHP_VERSION=8.3
+ARG PHP_BASE_IMAGE=ubuntu:24.04
 
 FROM debian:bookworm-slim AS package
 
@@ -19,9 +20,10 @@ RUN --mount=type=bind,source=dist/docker-packages,target=/mnt/packages,readonly 
     test -n "${archive}"; \
     tar -xzf "${archive}" -C /opt/king/package --strip-components=1
 
-FROM ubuntu:24.04 AS runtime
+FROM ${PHP_BASE_IMAGE} AS runtime
 
 ARG PHP_VERSION
+ARG PHP_BASE_IMAGE
 ARG BUILD_DATE
 ARG VCS_REF
 ENV DEBIAN_FRONTEND=noninteractive
@@ -31,31 +33,53 @@ LABEL org.opencontainers.image.title="king" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}"
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    gnupg \
-    libcurl3t64-gnutls \
-    libuuid1 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /usr/share/keyrings \
-    && curl --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors -fsSL \
+RUN set -eux; \
+    if command -v "php${PHP_VERSION}" >/dev/null 2>&1; then \
+      ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php; \
+    else \
+      for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+        if [ -f "${source_file}" ]; then \
+          sed -i \
+            -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
+            "${source_file}"; \
+        fi; \
+      done; \
+      apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        -o Acquire::ForceIPv4=true \
+        update; \
+      apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        libcurl3t64-gnutls \
+        libuuid1; \
+      mkdir -p /usr/share/keyrings; \
+      curl --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors -fsSL \
         'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB8DC7E53946656EFBCE4C1DD71DAEAAB4AD4CAB6' \
-        | gpg --dearmor -o /usr/share/keyrings/ondrej-php.gpg \
-    && . /etc/os-release \
-    && printf 'deb [signed-by=/usr/share/keyrings/ondrej-php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu %s main\n' "${VERSION_CODENAME}" \
-        > /etc/apt/sources.list.d/ondrej-php.list \
-    && apt-get -o Acquire::Retries=5 update \
-    && apt-get install -y --no-install-recommends \
-        "php${PHP_VERSION}-cli" \
-        "php${PHP_VERSION}-curl" \
-        "php${PHP_VERSION}-mbstring" \
-        "php${PHP_VERSION}-sockets" \
-        "php${PHP_VERSION}-sqlite3" \
-        "php${PHP_VERSION}-xml" \
-    && ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php \
-    && rm -rf /var/lib/apt/lists/*
+        | gpg --dearmor -o /usr/share/keyrings/ondrej-php.gpg; \
+      . /etc/os-release; \
+      printf 'deb [signed-by=/usr/share/keyrings/ondrej-php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu %s main\n' "${VERSION_CODENAME}" \
+        > /etc/apt/sources.list.d/ondrej-php.list; \
+      apt-get \
+        -o Acquire::Retries=5 \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        -o Acquire::ForceIPv4=true \
+        update; \
+      apt-get install -y --no-install-recommends \
+          "php${PHP_VERSION}-cli" \
+          "php${PHP_VERSION}-curl" \
+          "php${PHP_VERSION}-mbstring" \
+          "php${PHP_VERSION}-sockets" \
+          "php${PHP_VERSION}-sqlite3" \
+          "php${PHP_VERSION}-xml"; \
+      ln -sf "/usr/bin/php${PHP_VERSION}" /usr/local/bin/php; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
 
 RUN mkdir -p /opt/king /workspace
 


### PR DESCRIPTION
## Summary
- add `ensure-php-base-images` job to release publish workflow
- check GHCR base-image tags per PHP version and rebuild only when missing or stale
- introduce shared `infra/php-runtime-base.Dockerfile`
- wire `PHP_BASE_IMAGE` into runtime/demo Docker builds so apt/PPA provisioning is skipped when base already contains the required PHP toolchain
- keep fallback provisioning in runtime/demo Dockerfiles for resilience

## Why
CI repeatedly hits flaky external package infrastructure (Ubuntu mirrors / PPA keyserver). Prebuilding and reusing a PHP base image reduces those failures and avoids unnecessary rebuild work.

## Notes
- staleness threshold controlled via `PHP_BASE_MAX_AGE_DAYS` (currently `14`)
- release workflow YAML was syntax-validated locally
