### PR TITLE
Enforce SFU capture profile constraints

### DIFF
--- a/SPRINT.md
+++ b/SPRINT.md
@@ -12,99 +12,50 @@ Sprint rule:
 - Keep media-security, binary SFU envelopes, bounded SQLite frame buffering, live relay, receiver feedback, and online pressure contracts intact.
 - Video quality must stay automatic; there must be no user-facing quality selector in the call UI.
 
-## Sprint: Video Call Performance And Quality Hardening
+## Sprint: Video Call Capture Profile Coupling
 
 Sprint branch:
-- `sprint/video-call-performance-quality`
+- `sprint/video-call-capture-profile-coupling`
 
 PR target:
 - `development/1.0.7-beta`
 
 Deployed baseline:
-- `development/1.0.7-beta` includes the deployed bounded SQLite SFU frame-buffer hotfix from merge `d1da7fe`.
-- Production deploy smoke passed after the hotfix deploy on `https://kingrt.com/`.
+- `development/1.0.7-beta` includes the merged video-call performance/quality hardening branch with deterministic `VideoFrame` closure and the copyTo-first capture path.
 
-Production symptoms:
-- High-motion calls can still collapse into visibly blocky video or freeze/reconnect loops.
-- The current diagnostics identify the publisher-side bottleneck at source readback, WLVC motion delta pressure, or SFU replay/send pacing, but the next sprint must remove the remaining throughput waste instead of hiding it behind lower quality.
-- Browser console warnings such as leaked `VideoFrame` objects are release blockers because they can cause stalls under pressure.
+Production symptom:
+- Video quality improved after fixing the `VideoFrame` lifecycle, but publisher capture can still waste throughput when the browser returns a larger camera track than the active automatic SFU profile needs.
+- `getUserMedia` asks for profile-capped dimensions, but fallback/browser selection can still leave the real track oversized until readback diagnostics notice it.
 
 Technical target:
-- Keep protected SFU media on.
-- Preserve bounded SQLite buffering for short replay/backfill.
-- Maximize real moving-video quality by removing unnecessary main-thread readback work, stabilizing WLVC delta generation under motion, and preventing slow subscribers or replay bursts from pressuring healthy publishers.
+- Couple the real camera track to the active automatic SFU profile before source readback.
+- Avoid copying/scaling oversized source frames when the browser supports track constraints.
+- Keep quality selection fully automatic and report the exact requested/applied capture envelope to backend diagnostics.
 
 ## Active Issues
 
-1. [x] `[readback-zero-copy-gate]` Remove source readback as a normal hotpath bottleneck.
+1. [x] `[capture-profile-track-constraints]` Enforce automatic SFU profile constraints on the actual camera track.
 
    Scope:
-   - Audit the full publisher path from `MediaStreamTrackProcessor` frame pull through `VideoFrame.copyTo`, worker fallback, WLVC input normalization, protected frame wrapping, and SFU socket send.
-   - Make the normal supported-browser path avoid DOM canvas readback entirely for profile-matched frames.
-   - Keep DOM canvas only as a capped compatibility fallback with explicit backend-routed diagnostics.
-   - Close every `VideoFrame` deterministically on success, skip, timeout, worker transfer, fallback, and error paths.
-   - Add an acceptance gate that fails on `sfu_source_readback_budget_exceeded`, leaked `VideoFrame` warnings, or main-thread canvas readback being selected when zero-copy support is available.
+   - Add a focused helper for SFU capture-profile track constraints instead of growing `CallWorkspaceView.vue` or `mediaOrchestration.js`.
+   - Apply `width`, `height`, and `frameRate` caps to the selected video track after strict, loose, and boolean-fallback `getUserMedia` acquisition.
+   - Respect browser-reported camera capabilities so impossible min/max constraints do not break capture.
+   - Keep capture settings and constraint failures in backend diagnostics, not as browser-console noise.
+   - Prove the real track cap happens before WLVC source readback.
 
    Done when:
-   - High-motion online pressure runs do not emit `sfu_source_readback_budget_exceeded`.
-   - Console-visible `VideoFrame was garbage collected without being closed` warnings are gone.
-   - Backend diagnostics still record the exact active capture backend and source timing.
+   - Capable camera tracks receive `applyConstraints()` for the active automatic SFU profile after browser track selection.
+   - Boolean `getUserMedia` fallback cannot silently leave an oversized HD source without a follow-up profile constraint attempt.
+   - `mediaOrchestration.js` stays below the 800-line target by extracting the constraint/reporting code.
 
    Report:
-   - Aligned automatic capture dimensions with published profile dimensions and hard-capped browser capture width/height/FPS in `getUserMedia` constraints.
-   - Added source-dimension `VideoFrame.copyTo(..., { format: 'RGBA' })` sizing so profile-matched and capture-matched frames do not fall into DOM canvas scaling.
-   - Added the zero-copy capture gate: if a browser supports the VideoFrame copy path, main-thread canvas readback from a `VideoFrame` source is blocked and reported as exact source-readback pressure instead of silently using `drawImage/getImageData`.
-   - Added `sfu-zero-copy-readback-gate-contract.mjs` and extended the RGBA copy contract.
-   - Verification: `npm run test:contract:sfu`, `npm run build`.
-
-2. [x] `[wlvc-motion-delta-rate-control]` Stabilize WLVC quality under movement instead of collapsing into blocky frames.
-
-   Scope:
-   - Analyze the WLVC encode path for high-motion delta explosion, tile/ROI churn, keyframe cadence, and profile downgrade thresholds.
-   - Prefer framerate and delta cadence control before destructive resolution collapse when motion spikes.
-   - Add motion-aware keyframe and recovery probing so quality can return after a stable window without SFU socket churn.
-   - Keep profile selection automatic and remove any remaining user-facing quality control paths.
-   - Route codec and profile warnings to backend diagnostics instead of browser console noise.
-
-   Done when:
-   - High-motion calls stay moving at the best sustainable profile instead of dropping straight to unusable block quality.
-   - Automatic downgrade and recovery decisions are visible in backend diagnostics.
-   - The call UI has no manual quality selector.
-
-   Report:
-   - Added motion-delta cadence throttling to the publisher backpressure controller: first WLVC payload pressure now slows the encode interval and forces a recoverable keyframe before any destructive profile downshift.
-   - Kept profile downshift automatic and thresholded: repeated motion payload pressure can still step down after cadence throttling fails, while protected-media budget pressure remains an immediate safety downshift.
-   - Wired the active cadence multiplier into the local publisher pipeline through `sfuTransport.resolveWlvcEncodeIntervalMs(...)`.
-   - Added automatic cadence recovery and backend diagnostics for `sfu_wlvc_motion_delta_cadence_throttled`, `sfu_wlvc_motion_delta_cadence_recovered`, and `sfu_wlvc_motion_delta_recovered`.
-   - Fixed WLVC chroma delta coding in both TypeScript and WASM C++ sources using a dedicated `bit2=chroma_temporal_residual` flag, then rebuilt `wlvc.js`/`wlvc.wasm` with the ES module factory wrapper intact.
-   - Updated contracts so stable video status is backend-diagnostic based instead of console-log based, and so high-motion tests assert cadence-first behavior plus moving-chroma delta decode.
-   - Verification: `npm run test:contract:sfu`, `npm run test:contract:wlvc`, `node tests/contract/wlvc-wasm-config-surface-contract.mjs`, `node tests/contract/call-layout-sidebar-controls-contract.mjs`, `npm run build`.
-
-3. [x] `[sfu-replay-pacing-slow-subscriber-isolation]` Smooth SFU send/replay pressure without punishing healthy publishers.
-
-   Scope:
-   - Trace the backend SFU receive, live relay, bounded SQLite frame buffer, subscriber cursor, and replay loops for throughput stalls.
-   - Add or tighten per-subscriber pacing so slow consumers drop stale deltas, request/receive keyframes first, and cannot create publisher backpressure.
-   - Keep the bounded SQLite buffer as a short replay/backfill mechanism, not an unbounded frame store.
-   - Prove binary envelope validation, media-security, room admission, and duplicate suppression still hold.
-   - Add production diagnostics that distinguish live-send pressure, replay pressure, slow-subscriber pressure, and publisher-source pressure.
-
-   Done when:
-   - Slow subscriber simulations do not trigger healthy publisher downgrades or reconnect loops.
-   - Replayed frames are bounded, ordered, and stale-frame-pruned.
-   - Backend diagnostics identify the exact pressure station without browser console warnings.
-
-   Report:
-   - Added a budgeted replay sender shared by live relay and bounded SQLite replay so slow subscribers are cooled down before replay sends can burn request-loop time.
-   - Added replay-specific pacing limits: stricter send budget, capped replay batch size, stale-delta pruning, and pre-keyframe delta pruning so replay starts from the nearest useful keyframe instead of flooding old deltas.
-   - Kept bounded SQLite buffering intact as a short replay/backfill mechanism and left direct live fanout on the existing binary-required path.
-   - Added backend diagnostics for `sfu_frame_replay_stale_delta_pruned`, `sfu_frame_replay_pre_keyframe_delta_pruned`, `sfu_frame_replay_slow_subscriber_skipped`, and `sfu_frame_replay_slow_subscriber_isolated`, each tagged with the exact `sfu_send_path`.
-   - Kept `realtime_sfu_gateway.php` under the 800-line source target while threading the shared subscriber cooldown into live-relay and SQLite replay polls.
-   - Verification: `php -l` on changed PHP files, `npm run test:contract:sfu`, `php demo/video-chat/backend-king-php/tests/realtime-sfu-contract.php` (local `pdo_sqlite` skip), `npm run build`.
+   - Added `sfuCaptureProfileConstraints.js` with `buildSfuVideoProfileTrackConstraints(...)`, `applySfuVideoProfileConstraintsToStream(...)`, and shared capture diagnostics.
+   - Enforced active profile constraints immediately after strict, loose-retry, and boolean-fallback camera acquisition.
+   - Moved local capture settings reporting out of `mediaOrchestration.js`, reducing it from 801 to 778 lines.
+   - Extended SFU contracts to assert actual track `applyConstraints()` enforcement, capability clamping, diagnostics, and fallback coverage.
 
 ## Execution Order
 
-1. Finish `[readback-zero-copy-gate]` first; source readback failures are currently the clearest hard bottleneck.
-2. Then harden `[wlvc-motion-delta-rate-control]`; this determines visible quality once source readback is no longer the choke point.
-3. Finish with `[sfu-replay-pacing-slow-subscriber-isolation]`; this protects multi-party and slow-client cases without weakening media security or buffering.
-4. Commit after each checkbox, deploy after each completed issue, and add a short report under the issue before checking it off.
+1. Finish `[capture-profile-track-constraints]`.
+2. Deploy after the issue is completed.
+3. Push the sprint branch after deploy verification.

--- a/demo/video-chat/frontend-vue/src/domain/realtime/local/mediaOrchestration.js
+++ b/demo/video-chat/frontend-vue/src/domain/realtime/local/mediaOrchestration.js
@@ -1,8 +1,8 @@
+import { buildOptionalCallAudioCaptureConstraints } from '../media/audioCaptureConstraints';
 import {
-  detectPublisherCapturePipelineCapabilities,
-  publisherCaptureCapabilityDiagnosticPayload,
-} from './capturePipelineCapabilities';
-import { buildOptionalCallAudioCaptureConstraints, callAudioSettingsDiagnosticPayload } from '../media/audioCaptureConstraints';
+  applySfuVideoProfileConstraintsToStream,
+  reportSfuLocalCaptureSettings,
+} from './sfuCaptureProfileConstraints';
 export function createLocalMediaOrchestrationHelpers({
   backgroundBaselineCollector,
   backgroundFilterController,
@@ -120,52 +120,23 @@ export function createLocalMediaOrchestrationHelpers({
     };
   }
 
-  function finiteTrackSetting(value) {
-    const normalized = Number(value);
-    return Number.isFinite(normalized) && normalized > 0 ? normalized : 0;
+  function reportLocalCaptureSettings(stream, reason) {
+    reportSfuLocalCaptureSettings({
+      stream,
+      reason,
+      videoProfile: currentSfuVideoProfile(),
+      captureDiagnostic,
+    });
   }
 
-  function reportLocalCaptureSettings(stream, reason) {
-    const videoTrack = stream instanceof MediaStream ? stream.getVideoTracks?.()[0] || null : null;
-    const audioTrack = stream instanceof MediaStream ? stream.getAudioTracks?.()[0] || null : null;
-    if (!audioTrack && (!videoTrack || typeof videoTrack.getSettings !== 'function')) return;
-    const videoProfile = currentSfuVideoProfile();
-    const profileId = String(videoProfile.id || '').trim() || 'balanced';
-    const settings = videoTrack && typeof videoTrack.getSettings === 'function' ? videoTrack.getSettings() || {} : {};
-    const settingsWidth = finiteTrackSetting(settings.width);
-    const settingsHeight = finiteTrackSetting(settings.height);
-    const settingsFrameRate = finiteTrackSetting(settings.frameRate);
-    const captureCapabilities = detectPublisherCapturePipelineCapabilities();
-    const staleAfterDowngrade = (profileId === 'realtime' || profileId === 'rescue')
-      && (
-        (settingsWidth > 0 && settingsWidth > Number(videoProfile.captureWidth || 0) * 1.25)
-        || (settingsHeight > 0 && settingsHeight > Number(videoProfile.captureHeight || 0) * 1.25)
-      );
-    captureDiagnostic({
-      category: 'media',
-      level: staleAfterDowngrade ? 'warning' : 'info',
-      eventType: 'sfu_local_capture_constraints_applied',
-      code: 'sfu_local_capture_constraints_applied',
-      message: 'Browser-reported local capture settings after applying the selected SFU video profile.',
-      payload: {
-        reason: String(reason || 'unknown'),
-        outgoing_video_quality_profile: profileId,
-        requested_capture_width: Number(videoProfile.captureWidth || 0),
-        requested_capture_height: Number(videoProfile.captureHeight || 0),
-        requested_capture_frame_rate: Number(videoProfile.captureFrameRate || 0),
-        requested_readback_frame_rate: Number(videoProfile.readbackFrameRate || 0),
-        requested_readback_interval_ms: Number(videoProfile.readbackIntervalMs || videoProfile.encodeIntervalMs || 0),
-        requested_keyframe_interval: Number(videoProfile.keyFrameInterval || 0),
-        requested_wire_budget_bytes_per_second: Number(videoProfile.maxWireBytesPerSecond || 0),
-        publisher_frame_width: Number(videoProfile.frameWidth || 0),
-        publisher_frame_height: Number(videoProfile.frameHeight || 0),
-        track_settings_width: settingsWidth,
-        track_settings_height: settingsHeight,
-        track_settings_frame_rate: settingsFrameRate,
-        ...callAudioSettingsDiagnosticPayload(audioTrack),
-        ...publisherCaptureCapabilityDiagnosticPayload(captureCapabilities),
-        stale_hd_capture_after_downgrade: staleAfterDowngrade,
-      },
+  async function enforceSfuVideoCaptureProfile(stream, reason) {
+    return applySfuVideoProfileConstraintsToStream({
+      stream,
+      reason,
+      videoProfile: currentSfuVideoProfile(),
+      captureDiagnostic,
+      captureClientDiagnosticError,
+      mediaRuntimePath: refs.mediaRuntimePathRef.value,
     });
   }
 
@@ -185,7 +156,9 @@ export function createLocalMediaOrchestrationHelpers({
     }
 
     try {
-      return await navigator.mediaDevices.getUserMedia(strictConstraints);
+      const stream = await navigator.mediaDevices.getUserMedia(strictConstraints);
+      await enforceSfuVideoCaptureProfile(stream, 'strict');
+      return stream;
     } catch (error) {
       if (!shouldRetryWithLooseConstraints(error)) {
         throw error;
@@ -193,7 +166,9 @@ export function createLocalMediaOrchestrationHelpers({
     }
 
     try {
-      return await navigator.mediaDevices.getUserMedia(looseConstraints);
+      const stream = await navigator.mediaDevices.getUserMedia(looseConstraints);
+      await enforceSfuVideoCaptureProfile(stream, 'loose_retry');
+      return stream;
     } catch {
       const fallbackConstraints = {
         video: controlState.cameraEnabled !== false,
@@ -202,7 +177,9 @@ export function createLocalMediaOrchestrationHelpers({
       if (fallbackConstraints.video !== true && fallbackConstraints.audio !== true) {
         return new MediaStream();
       }
-      return navigator.mediaDevices.getUserMedia(fallbackConstraints);
+      const stream = await navigator.mediaDevices.getUserMedia(fallbackConstraints);
+      await enforceSfuVideoCaptureProfile(stream, 'boolean_fallback');
+      return stream;
     }
   }
 

--- a/demo/video-chat/frontend-vue/src/domain/realtime/local/sfuCaptureProfileConstraints.js
+++ b/demo/video-chat/frontend-vue/src/domain/realtime/local/sfuCaptureProfileConstraints.js
@@ -1,0 +1,188 @@
+import {
+  detectPublisherCapturePipelineCapabilities,
+  publisherCaptureCapabilityDiagnosticPayload,
+} from './capturePipelineCapabilities';
+import { callAudioSettingsDiagnosticPayload } from '../media/audioCaptureConstraints';
+
+function positiveNumber(value) {
+  const normalized = Number(value);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : 0;
+}
+
+function finiteTrackSetting(value) {
+  const normalized = Number(value);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : 0;
+}
+
+function firstTrack(stream, getterName) {
+  const getter = stream && typeof stream[getterName] === 'function' ? stream[getterName] : null;
+  if (!getter) return null;
+  const tracks = getter.call(stream);
+  return Array.isArray(tracks) ? tracks[0] || null : null;
+}
+
+function resolveCappedConstraint(targetValue, capability = {}) {
+  const target = positiveNumber(targetValue);
+  if (target <= 0) return null;
+
+  const min = positiveNumber(capability?.min);
+  const max = positiveNumber(capability?.max);
+  let capped = target;
+  if (max > 0) capped = Math.min(capped, max);
+  if (min > 0) capped = Math.max(capped, min);
+
+  return { ideal: capped, max: capped };
+}
+
+function profileId(videoProfile = {}) {
+  return String(videoProfile.id || '').trim() || 'balanced';
+}
+
+function trackSettings(videoTrack) {
+  if (!videoTrack || typeof videoTrack.getSettings !== 'function') return {};
+  try {
+    return videoTrack.getSettings() || {};
+  } catch {
+    return {};
+  }
+}
+
+function trackCapabilities(videoTrack) {
+  if (!videoTrack || typeof videoTrack.getCapabilities !== 'function') return {};
+  try {
+    return videoTrack.getCapabilities() || {};
+  } catch {
+    return {};
+  }
+}
+
+export function buildSfuVideoProfileTrackConstraints(videoProfile = {}, videoTrack = null) {
+  const capabilities = trackCapabilities(videoTrack);
+  const constraints = {};
+  const width = resolveCappedConstraint(videoProfile.captureWidth, capabilities.width);
+  const height = resolveCappedConstraint(videoProfile.captureHeight, capabilities.height);
+  const frameRate = resolveCappedConstraint(videoProfile.captureFrameRate, capabilities.frameRate);
+
+  if (width) constraints.width = width;
+  if (height) constraints.height = height;
+  if (frameRate) constraints.frameRate = frameRate;
+  return constraints;
+}
+
+export function captureSettingsPayload({ videoTrack, audioTrack, videoProfile = {}, reason = 'unknown' } = {}) {
+  const settings = trackSettings(videoTrack);
+  const settingsWidth = finiteTrackSetting(settings.width);
+  const settingsHeight = finiteTrackSetting(settings.height);
+  const settingsFrameRate = finiteTrackSetting(settings.frameRate);
+  const captureCapabilities = detectPublisherCapturePipelineCapabilities();
+  const staleAfterDowngrade = (profileId(videoProfile) === 'realtime' || profileId(videoProfile) === 'rescue')
+    && (
+      (settingsWidth > 0 && settingsWidth > Number(videoProfile.captureWidth || 0) * 1.25)
+      || (settingsHeight > 0 && settingsHeight > Number(videoProfile.captureHeight || 0) * 1.25)
+    );
+
+  return {
+    payload: {
+      reason: String(reason || 'unknown'),
+      outgoing_video_quality_profile: profileId(videoProfile),
+      requested_capture_width: Number(videoProfile.captureWidth || 0),
+      requested_capture_height: Number(videoProfile.captureHeight || 0),
+      requested_capture_frame_rate: Number(videoProfile.captureFrameRate || 0),
+      requested_readback_frame_rate: Number(videoProfile.readbackFrameRate || 0),
+      requested_readback_interval_ms: Number(videoProfile.readbackIntervalMs || videoProfile.encodeIntervalMs || 0),
+      requested_keyframe_interval: Number(videoProfile.keyFrameInterval || 0),
+      requested_wire_budget_bytes_per_second: Number(videoProfile.maxWireBytesPerSecond || 0),
+      publisher_frame_width: Number(videoProfile.frameWidth || 0),
+      publisher_frame_height: Number(videoProfile.frameHeight || 0),
+      track_settings_width: settingsWidth,
+      track_settings_height: settingsHeight,
+      track_settings_frame_rate: settingsFrameRate,
+      ...callAudioSettingsDiagnosticPayload(audioTrack),
+      ...publisherCaptureCapabilityDiagnosticPayload(captureCapabilities),
+      stale_hd_capture_after_downgrade: staleAfterDowngrade,
+    },
+    staleAfterDowngrade,
+  };
+}
+
+export function reportSfuLocalCaptureSettings({
+  stream,
+  videoProfile = {},
+  reason = 'unknown',
+  captureDiagnostic = () => {},
+} = {}) {
+  const videoTrack = firstTrack(stream, 'getVideoTracks');
+  const audioTrack = firstTrack(stream, 'getAudioTracks');
+  if (!audioTrack && (!videoTrack || typeof videoTrack.getSettings !== 'function')) return false;
+
+  const { payload, staleAfterDowngrade } = captureSettingsPayload({
+    videoTrack,
+    audioTrack,
+    videoProfile,
+    reason,
+  });
+  captureDiagnostic({
+    category: 'media',
+    level: staleAfterDowngrade ? 'warning' : 'info',
+    eventType: 'sfu_local_capture_constraints_applied',
+    code: 'sfu_local_capture_constraints_applied',
+    message: 'Browser-reported local capture settings after applying the selected SFU video profile.',
+    payload,
+  });
+  return true;
+}
+
+export async function applySfuVideoProfileConstraintsToStream({
+  stream,
+  videoProfile = {},
+  reason = 'unknown',
+  captureDiagnostic = () => {},
+  captureClientDiagnosticError = () => {},
+  mediaRuntimePath = '',
+} = {}) {
+  const videoTrack = firstTrack(stream, 'getVideoTracks');
+  if (!videoTrack || typeof videoTrack.applyConstraints !== 'function') {
+    return { ok: false, applied: false, reason: 'sfu_capture_track_constraints_unsupported' };
+  }
+
+  const constraints = buildSfuVideoProfileTrackConstraints(videoProfile, videoTrack);
+  if (Object.keys(constraints).length === 0) {
+    return { ok: false, applied: false, reason: 'sfu_capture_track_constraints_empty' };
+  }
+
+  try {
+    await videoTrack.applyConstraints(constraints);
+    captureDiagnostic({
+      category: 'media',
+      level: 'info',
+      eventType: 'sfu_capture_track_constraints_enforced',
+      code: 'sfu_capture_track_constraints_enforced',
+      message: 'Local camera track constraints were enforced for the active automatic SFU video profile.',
+      payload: {
+        reason: String(reason || 'unknown'),
+        outgoing_video_quality_profile: profileId(videoProfile),
+        requested_capture_width: Number(videoProfile.captureWidth || 0),
+        requested_capture_height: Number(videoProfile.captureHeight || 0),
+        requested_capture_frame_rate: Number(videoProfile.captureFrameRate || 0),
+        applied_width_max: Number(constraints.width?.max || 0),
+        applied_height_max: Number(constraints.height?.max || 0),
+        applied_frame_rate_max: Number(constraints.frameRate?.max || 0),
+        media_runtime_path: String(mediaRuntimePath || ''),
+      },
+    });
+    return { ok: true, applied: true, constraints };
+  } catch (error) {
+    captureClientDiagnosticError('sfu_capture_track_constraints_failed', error, {
+      reason: String(reason || 'unknown'),
+      outgoing_video_quality_profile: profileId(videoProfile),
+      requested_capture_width: Number(videoProfile.captureWidth || 0),
+      requested_capture_height: Number(videoProfile.captureHeight || 0),
+      requested_capture_frame_rate: Number(videoProfile.captureFrameRate || 0),
+      media_runtime_path: String(mediaRuntimePath || ''),
+    }, {
+      code: 'sfu_capture_track_constraints_failed',
+      immediate: true,
+    });
+    return { ok: false, applied: false, reason: 'sfu_capture_track_constraints_failed', error };
+  }
+}

--- a/demo/video-chat/frontend-vue/tests/contract/sfu-capture-constraints-contract.mjs
+++ b/demo/video-chat/frontend-vue/tests/contract/sfu-capture-constraints-contract.mjs
@@ -22,6 +22,7 @@ function read(relativePath) {
 
 async function main() {
   const mediaOrchestration = read('src/domain/realtime/local/mediaOrchestration.js');
+  const captureProfileConstraints = read('src/domain/realtime/local/sfuCaptureProfileConstraints.js');
   const mediaStack = read('src/domain/realtime/workspace/callWorkspace/mediaStack.js');
   const publisherPipeline = read('src/domain/realtime/local/publisherPipeline.js');
   const publisherFrameTrace = read('src/domain/realtime/local/publisherFrameTrace.js');
@@ -35,9 +36,16 @@ async function main() {
   const lifecycle = read('src/domain/realtime/workspace/callWorkspace/lifecycle.js');
 
   requireContains(mediaStack, 'captureClientDiagnostic: callbacks.captureClientDiagnostic', 'media stack passes diagnostics into local media orchestration');
-  requireContains(mediaOrchestration, 'videoTrack.getSettings()', 'local media orchestration reads browser-reported track settings');
+  requireContains(captureProfileConstraints, 'videoTrack.getSettings()', 'capture profile constraints read browser-reported track settings');
+  requireContains(captureProfileConstraints, 'buildSfuVideoProfileTrackConstraints', 'capture profile constraints build hard track constraints');
+  requireContains(captureProfileConstraints, 'videoTrack.applyConstraints(constraints)', 'capture profile constraints enforce the active profile on the real camera track');
+  requireContains(captureProfileConstraints, 'sfu_capture_track_constraints_enforced', 'capture profile constraints report successful track enforcement');
+  requireContains(captureProfileConstraints, 'sfu_capture_track_constraints_failed', 'capture profile constraints report failed track enforcement');
   requireContains(mediaOrchestration, 'frameRate: { ideal: videoProfile.captureFrameRate, max: videoProfile.captureFrameRate }', 'local media constraints cap capture FPS to automatic profile');
-  requireContains(mediaOrchestration, 'sfu_local_capture_constraints_applied', 'local media orchestration reports applied capture settings');
+  requireContains(mediaOrchestration, "await enforceSfuVideoCaptureProfile(stream, 'strict')", 'strict local media acquisition enforces capture constraints after browser selection');
+  requireContains(mediaOrchestration, "await enforceSfuVideoCaptureProfile(stream, 'loose_retry')", 'loose local media retry enforces capture constraints after browser selection');
+  requireContains(mediaOrchestration, "await enforceSfuVideoCaptureProfile(stream, 'boolean_fallback')", 'boolean getUserMedia fallback still enforces capture constraints after browser selection');
+  requireContains(captureProfileConstraints, 'sfu_local_capture_constraints_applied', 'capture profile constraints report applied capture settings');
   requireContains(mediaOrchestration, 'buildOptionalCallAudioCaptureConstraints(wantsAudio, microphoneDeviceId)', 'local media constraints request browser echo cancellation for selected microphones');
   requireContains(mediaOrchestration, 'buildOptionalCallAudioCaptureConstraints(wantsAudio)', 'loose local media retry keeps echo cancellation enabled');
   requireContains(audioCaptureConstraints, 'audio_echo_cancellation', 'capture diagnostics report applied echo-cancellation settings');
@@ -55,7 +63,7 @@ async function main() {
     requireContains(source, 'buildOptionalCallAudioCaptureConstraints', `${label} uses shared call audio capture constraints`);
     assert.equal(source.includes('echoCancellation: false'), false, `${label} must not disable browser echo cancellation`);
   }
-  requireContains(mediaOrchestration, 'stale_hd_capture_after_downgrade', 'local media orchestration flags stale HD capture after downgrade');
+  requireContains(captureProfileConstraints, 'stale_hd_capture_after_downgrade', 'local capture diagnostics flag stale HD capture after downgrade');
   requireContains(mediaOrchestration, "reportLocalCaptureSettings(rawStream, 'publish')", 'initial publish reports track settings');
   requireContains(mediaOrchestration, "reportLocalCaptureSettings(nextRawStream, 'reconfigure')", 'profile/device reconfigure reports track settings');
   requireContains(lifecycle, 'void reconfigureLocalTracksFromSelectedDevices();', 'automatic quality profile change reconfigures local tracks');
@@ -75,6 +83,10 @@ async function main() {
     const { SFU_VIDEO_QUALITY_PROFILES } = await server.ssrLoadModule('/src/domain/realtime/workspace/config.js');
     const { resolveContainFrameSizeFromDimensions } = await server.ssrLoadModule('/src/domain/realtime/local/videoFrameSizing.js');
     const { buildCallAudioCaptureConstraints } = await server.ssrLoadModule('/src/domain/realtime/media/audioCaptureConstraints.js');
+    const {
+      applySfuVideoProfileConstraintsToStream,
+      buildSfuVideoProfileTrackConstraints,
+    } = await server.ssrLoadModule('/src/domain/realtime/local/sfuCaptureProfileConstraints.js');
     const quality = SFU_VIDEO_QUALITY_PROFILES.quality;
     const realtime = SFU_VIDEO_QUALITY_PROFILES.realtime;
     const rescue = SFU_VIDEO_QUALITY_PROFILES.rescue;
@@ -106,6 +118,51 @@ async function main() {
     const selectedAudio = buildCallAudioCaptureConstraints('mic-1');
     assert.equal(selectedAudio.deviceId.exact, 'mic-1', 'selected microphone id must be preserved with audio processing constraints');
     assert.equal(selectedAudio.echoCancellation, true, 'selected call audio must keep echo cancellation');
+
+    const fakeTrack = {
+      applied: null,
+      getCapabilities() {
+        return {
+          width: { min: 320, max: 1920 },
+          height: { min: 180, max: 1080 },
+          frameRate: { min: 5, max: 60 },
+        };
+      },
+      getSettings() {
+        return { width: 1920, height: 1080, frameRate: 60 };
+      },
+      async applyConstraints(constraints) {
+        this.applied = constraints;
+      },
+    };
+    const constraints = buildSfuVideoProfileTrackConstraints(realtime, fakeTrack);
+    assert.equal(constraints.width.max, realtime.captureWidth, 'track width max must follow the active SFU profile');
+    assert.equal(constraints.height.max, realtime.captureHeight, 'track height max must follow the active SFU profile');
+    assert.equal(constraints.frameRate.max, realtime.captureFrameRate, 'track FPS max must follow the active SFU profile');
+    const constrained = await applySfuVideoProfileConstraintsToStream({
+      stream: {
+        getVideoTracks: () => [fakeTrack],
+        getAudioTracks: () => [],
+      },
+      videoProfile: realtime,
+      reason: 'contract',
+      captureDiagnostic: () => {},
+      captureClientDiagnosticError: () => {
+        throw new Error('unexpected capture constraint failure');
+      },
+      mediaRuntimePath: 'wlvc_wasm',
+    });
+    assert.equal(constrained.ok, true, 'track constraint enforcement must succeed on capable tracks');
+    assert.equal(fakeTrack.applied.width.max, realtime.captureWidth, 'enforced track width must cap the source before readback');
+    assert.equal(fakeTrack.applied.frameRate.max, realtime.captureFrameRate, 'enforced track FPS must cap the source before readback');
+
+    const minClamped = buildSfuVideoProfileTrackConstraints(
+      { captureWidth: 160, captureHeight: 90, captureFrameRate: 2 },
+      fakeTrack,
+    );
+    assert.equal(minClamped.width.max, 320, 'track constraints must respect browser-reported camera minimum width');
+    assert.equal(minClamped.height.max, 180, 'track constraints must respect browser-reported camera minimum height');
+    assert.equal(minClamped.frameRate.max, 5, 'track constraints must respect browser-reported camera minimum FPS');
 
     process.stdout.write('[sfu-capture-constraints-contract] PASS\n');
   } finally {

--- a/demo/video-chat/frontend-vue/tests/contract/sfu-capture-pipeline-capabilities-contract.mjs
+++ b/demo/video-chat/frontend-vue/tests/contract/sfu-capture-pipeline-capabilities-contract.mjs
@@ -88,6 +88,7 @@ class CopylessVideoFrame {
 try {
   const detectorSource = read('src/domain/realtime/local/capturePipelineCapabilities.js');
   const mediaOrchestration = read('src/domain/realtime/local/mediaOrchestration.js');
+  const captureProfileConstraints = read('src/domain/realtime/local/sfuCaptureProfileConstraints.js');
   requireContains(detectorSource, 'MediaStreamTrackProcessor', 'MediaStreamTrackProcessor detection');
   requireContains(detectorSource, "prototypeMethod(VideoFrameCtor, 'copyTo')", 'VideoFrame.copyTo detection');
   requireContains(detectorSource, "prototypeMethod(VideoFrameCtor, 'close')", 'VideoFrame.close detection');
@@ -95,9 +96,10 @@ try {
   requireContains(detectorSource, 'MessageChannel', 'worker transfer detection');
   requireContains(detectorSource, 'supportsDomCanvasFallback', 'DOM canvas fallback detection');
   requireContains(detectorSource, 'publisherCaptureCapabilityDiagnosticPayload', 'diagnostic payload helper');
-  requireContains(mediaOrchestration, "from './capturePipelineCapabilities'", 'local media orchestration imports capture capability detector');
-  requireContains(mediaOrchestration, 'detectPublisherCapturePipelineCapabilities()', 'local capture diagnostics probe browser capability state');
-  requireContains(mediaOrchestration, 'publisherCaptureCapabilityDiagnosticPayload(captureCapabilities)', 'local capture diagnostics include capability payload');
+  requireContains(mediaOrchestration, "from './sfuCaptureProfileConstraints'", 'local media orchestration imports capture profile enforcement');
+  requireContains(captureProfileConstraints, "from './capturePipelineCapabilities'", 'capture profile enforcement imports capture capability detector');
+  requireContains(captureProfileConstraints, 'detectPublisherCapturePipelineCapabilities()', 'local capture diagnostics probe browser capability state');
+  requireContains(captureProfileConstraints, 'publisherCaptureCapabilityDiagnosticPayload(captureCapabilities)', 'local capture diagnostics include capability payload');
 
   const moduleUrl = pathToFileURL(path.resolve(frontendRoot, 'src/domain/realtime/local/capturePipelineCapabilities.js')).href;
   const {

--- a/demo/video-chat/frontend-vue/tests/contract/sfu-source-budget-profile-coupling-contract.mjs
+++ b/demo/video-chat/frontend-vue/tests/contract/sfu-source-budget-profile-coupling-contract.mjs
@@ -23,6 +23,7 @@ function read(relativePath) {
 async function main() {
   const workspaceConfig = read('src/domain/realtime/workspace/config.js');
   const mediaOrchestration = read('src/domain/realtime/local/mediaOrchestration.js');
+  const captureProfileConstraints = read('src/domain/realtime/local/sfuCaptureProfileConstraints.js');
   const publisherPipeline = read('src/domain/realtime/local/publisherPipeline.js');
   const sourceReadback = read('src/domain/realtime/local/publisherSourceReadback.js');
   const publisherFrameTrace = read('src/domain/realtime/local/publisherFrameTrace.js');
@@ -30,9 +31,13 @@ async function main() {
   requireContains(workspaceConfig, 'readbackFrameRate', 'profiles define readback FPS');
   requireContains(workspaceConfig, 'readbackIntervalMs', 'profiles define readback interval');
   requireContains(mediaOrchestration, 'frameRate: { ideal: videoProfile.captureFrameRate, max: videoProfile.captureFrameRate }', 'capture constraints hard-cap profile FPS');
-  requireContains(mediaOrchestration, 'requested_readback_frame_rate', 'capture diagnostics include readback FPS');
-  requireContains(mediaOrchestration, 'requested_keyframe_interval', 'capture diagnostics include keyframe cadence');
-  requireContains(mediaOrchestration, 'requested_wire_budget_bytes_per_second', 'capture diagnostics include wire budget');
+  requireContains(mediaOrchestration, 'applySfuVideoProfileConstraintsToStream', 'capture enforcement runs after browser track selection');
+  requireContains(captureProfileConstraints, 'applied_width_max', 'capture diagnostics expose enforced camera width max');
+  requireContains(captureProfileConstraints, 'applied_height_max', 'capture diagnostics expose enforced camera height max');
+  requireContains(captureProfileConstraints, 'applied_frame_rate_max', 'capture diagnostics expose enforced camera FPS max');
+  requireContains(captureProfileConstraints, 'requested_readback_frame_rate', 'capture diagnostics include readback FPS');
+  requireContains(captureProfileConstraints, 'requested_keyframe_interval', 'capture diagnostics include keyframe cadence');
+  requireContains(captureProfileConstraints, 'requested_wire_budget_bytes_per_second', 'capture diagnostics include wire budget');
   requireContains(publisherPipeline, 'resolveProfileReadbackIntervalMs(videoProfile)', 'publisher tick cadence uses profile readback interval');
   requireContains(sourceReadback, 'resolveProfileReadbackIntervalMs(activeProfile)', 'source readback timeouts use active profile interval');
   requireContains(publisherFrameTrace, 'readback_frame_rate', 'transport metrics include readback FPS');


### PR DESCRIPTION
## Summary
- enforce automatic SFU profile constraints on the real camera track after strict, loose-retry, and boolean-fallback getUserMedia acquisition
- extract capture-profile track constraint/reporting logic into a focused helper instead of growing CallWorkspaceView.vue
- extend SFU contracts for capability clamping, diagnostics, fallback coverage, and pre-readback enforcement

## Validation
- cd demo/video-chat/frontend-vue && npm run test:contract:sfu
- cd demo/video-chat/frontend-vue && npm run build
- git diff --check
- demo/video-chat/scripts/deploy.sh deploy
- demo/video-chat/scripts/deploy-smoke.sh

## Deployment
- Deployed asset version: 20260429111331
- Branch commit: 2cc1baf Enforce SFU capture profile constraints
