### PR TITLE
Fix release compatibility checks for legacy HTTP3 manifests

### DIFF
--- a/infra/scripts/check-persistence-migration.sh
+++ b/infra/scripts/check-persistence-migration.sh
@@ -253,7 +253,7 @@ verify_archive() {
 
     verify_args=(./infra/scripts/verify-release-package.sh --archive "${archive_path}")
     if [[ "${allow_missing_provenance}" == "1" ]]; then
-        verify_args+=(--allow-missing-provenance)
+        verify_args+=(--allow-missing-provenance --allow-legacy-http3-metadata)
     fi
 
     (

--- a/infra/scripts/check-release-package-manifest-contract.rb
+++ b/infra/scripts/check-release-package-manifest-contract.rb
@@ -4,6 +4,8 @@ ROOT_DIR = File.expand_path("../..", __dir__)
 
 PACKAGE_SCRIPT = "infra/scripts/package-release.sh"
 PACKAGE_VERIFIER = "infra/scripts/verify-release-package.sh"
+RELEASE_UPGRADE_CHECK = "infra/scripts/check-release-upgrade.sh"
+PERSISTENCE_MIGRATION_CHECK = "infra/scripts/check-persistence-migration.sh"
 
 PROVENANCE_HASH_KEYS = %w[
   lsquic_bootstrap_lock_sha256
@@ -55,6 +57,8 @@ end
 
 package_script = read_repo(PACKAGE_SCRIPT)
 package_verifier = read_repo(PACKAGE_VERIFIER)
+release_upgrade_check = read_repo(RELEASE_UPGRADE_CHECK)
+persistence_migration_check = read_repo(PERSISTENCE_MIGRATION_CHECK)
 
 require_literal(package_script, "'http3_stack' => [", "package HTTP/3 stack manifest section")
 require_literal(package_script, "'transport' => 'lsquic'", "package LSQUIC transport manifest value")
@@ -80,9 +84,14 @@ TOP_LEVEL_PROVENANCE_KEYS.each do |component, provenance_key|
 end
 
 require_literal(package_verifier, "$assertLegacyHttp3Free($manifest, 'manifest');", "manifest legacy HTTP/3 exclusion scan")
+require_literal(package_verifier, "--allow-legacy-http3-metadata", "explicit previous-release legacy HTTP/3 compatibility option")
+require_literal(package_verifier, "if (!$allowLegacyHttp3Metadata)", "default release verification keeps legacy HTTP/3 metadata forbidden")
+require_literal(package_verifier, "is_array($provenance) && $manifestHasLegacyHttp3Metadata", "legacy HTTP/3 provenance bypass is scoped to explicit compatibility archives")
 require_literal(package_verifier, "array_keys($dependencyProvenance) !== $expectedComponents", "exact dependency component list gate")
 require_literal(package_verifier, "Manifest dependency provenance component list is invalid.", "dependency component list failure")
 require_literal(package_verifier, "Manifest dependency provenance hash does not match top-level provenance", "dependency hash binding failure")
+require_literal(release_upgrade_check, "verify_args+=(--allow-missing-provenance --allow-legacy-http3-metadata)", "upgrade/downgrade checks allow legacy previous-release HTTP/3 manifests only through explicit verifier flag")
+require_literal(persistence_migration_check, "verify_args+=(--allow-missing-provenance --allow-legacy-http3-metadata)", "persistence migration checks allow legacy previous-release HTTP/3 manifests only through explicit verifier flag")
 
 LEGACY_HTTP3_TOKENS.each do |token|
   fail_check("#{PACKAGE_SCRIPT} contains legacy HTTP/3 token #{token}") if package_script.downcase.include?(token.downcase)

--- a/infra/scripts/check-release-upgrade.sh
+++ b/infra/scripts/check-release-upgrade.sh
@@ -223,7 +223,7 @@ verify_archive() {
 
     verify_args=(./infra/scripts/verify-release-package.sh --archive "${archive_path}")
     if [[ "${allow_missing_provenance}" == "1" ]]; then
-        verify_args+=(--allow-missing-provenance)
+        verify_args+=(--allow-missing-provenance --allow-legacy-http3-metadata)
     fi
 
     (

--- a/infra/scripts/verify-release-package.sh
+++ b/infra/scripts/verify-release-package.sh
@@ -16,6 +16,7 @@ Verifies a packaged King release archive by checking:
 Options:
   --archive PATH                 Archive path to verify
   --allow-missing-provenance     Permit legacy manifests without provenance metadata
+  --allow-legacy-http3-metadata  Permit compatibility archives with legacy Quiche HTTP/3 manifest metadata
 EOF
 }
 
@@ -24,6 +25,7 @@ ARCHIVE_PATH=""
 PHP_BIN="${PHP_BIN:-php}"
 PACKAGE_DIR=""
 ALLOW_MISSING_PROVENANCE=0
+ALLOW_LEGACY_HTTP3_METADATA=0
 
 archive_entry_path_is_safe() {
     local entry="$1"
@@ -149,6 +151,10 @@ while [[ $# -gt 0 ]]; do
             ALLOW_MISSING_PROVENANCE=1
             shift
             ;;
+        --allow-legacy-http3-metadata)
+            ALLOW_LEGACY_HTTP3_METADATA=1
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -247,6 +253,7 @@ echo "Verifying package-local checksums..."
 echo "Verifying manifest metadata..."
 PACKAGE_DIR="${PACKAGE_DIR}" \
 ALLOW_MISSING_PROVENANCE="${ALLOW_MISSING_PROVENANCE}" \
+ALLOW_LEGACY_HTTP3_METADATA="${ALLOW_LEGACY_HTTP3_METADATA}" \
 "${PHP_BIN}" <<'PHP'
 <?php
 
@@ -254,6 +261,7 @@ declare(strict_types=1);
 
 $packageDir = getenv('PACKAGE_DIR');
 $allowMissingProvenance = getenv('ALLOW_MISSING_PROVENANCE') === '1';
+$allowLegacyHttp3Metadata = getenv('ALLOW_LEGACY_HTTP3_METADATA') === '1';
 if (!is_string($packageDir) || $packageDir === '') {
     fwrite(STDERR, "Missing PACKAGE_DIR environment variable.\n");
     exit(1);
@@ -278,6 +286,34 @@ $legacyHttp3Tokens = [
     'Cargo.toml',
     'Cargo.lock',
 ];
+
+$containsLegacyHttp3Metadata = static function (mixed $value) use (&$containsLegacyHttp3Metadata, $legacyHttp3Tokens): bool {
+    if (is_string($value)) {
+        foreach ($legacyHttp3Tokens as $token) {
+            if (stripos($value, $token) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    if (!is_array($value)) {
+        return false;
+    }
+
+    foreach ($value as $key => $child) {
+        if (is_string($key) && $containsLegacyHttp3Metadata($key)) {
+            return true;
+        }
+
+        if ($containsLegacyHttp3Metadata($child)) {
+            return true;
+        }
+    }
+
+    return false;
+};
 
 $assertLegacyHttp3Free = static function (mixed $value, string $path) use (&$assertLegacyHttp3Free, $legacyHttp3Tokens): void {
     if (is_string($value)) {
@@ -305,7 +341,10 @@ $assertLegacyHttp3Free = static function (mixed $value, string $path) use (&$ass
     }
 };
 
-$assertLegacyHttp3Free($manifest, 'manifest');
+$manifestHasLegacyHttp3Metadata = $containsLegacyHttp3Metadata($manifest);
+if (!$allowLegacyHttp3Metadata) {
+    $assertLegacyHttp3Free($manifest, 'manifest');
+}
 
 if (($manifest['package_format'] ?? null) !== 1) {
     fwrite(STDERR, "Unexpected manifest package_format.\n");
@@ -344,7 +383,12 @@ if (!is_array($provenance)) {
     }
 }
 
-if (is_array($provenance)) {
+if (is_array($provenance) && $manifestHasLegacyHttp3Metadata) {
+    if (!$allowLegacyHttp3Metadata) {
+        fwrite(STDERR, "Manifest contains legacy HTTP/3 metadata.\n");
+        exit(1);
+    }
+} elseif (is_array($provenance)) {
     $artifacts = $manifest['artifacts'] ?? null;
     if (!is_array($artifacts)) {
         fwrite(STDERR, "Manifest artifacts metadata is missing.\n");


### PR DESCRIPTION
## Summary

- allow the release compatibility harnesses to verify older 1.0.6 archives that still contain Quiche HTTP/3 manifest metadata
- keep the normal/current release package verifier strict: current artifacts must remain LSQUIC-based and legacy HTTP/3 metadata stays forbidden by default
- cover the compatibility exception in the manifest contract

## Validation

- `bash -n infra/scripts/verify-release-package.sh infra/scripts/check-release-upgrade.sh infra/scripts/check-release-downgrade.sh infra/scripts/check-persistence-migration.sh`
- `ruby infra/scripts/check-release-package-manifest-contract.rb`
- locally reproduced the failing paths earlier with `ca2224ab9edb11865bbe4abb19683c0dab3261c3`: upgrade, downgrade, and persistence migration all passed with the explicit legacy-previous-archive flag
