### PR TITLE
test: prevent borked reuseport skip probes

### DIFF
--- a/extension/tests/740-http1-listener-exclusive-bind-contract.phpt
+++ b/extension/tests/740-http1-listener-exclusive-bind-contract.phpt
@@ -11,44 +11,22 @@ if (!is_readable('/proc/net/tcp')) {
     return;
 }
 
-$probe = false;
-$checkPython = proc_open(
-    ['command', '-v', 'python3'],
+$checkReusePort = @proc_open(
+    ['python3', '-c', "import socket; raise SystemExit(0 if hasattr(socket, 'SO_REUSEPORT') else 1)"],
     [
         1 => ['pipe', 'w'],
         2 => ['pipe', 'w'],
     ],
-    $pythonPipes
+    $reusePortPipes
 );
-if (is_resource($checkPython)) {
-    stream_get_contents($pythonPipes[1]);
-    stream_get_contents($pythonPipes[2]);
-    foreach ($pythonPipes as $pipe) {
+$probe = false;
+if (is_resource($checkReusePort)) {
+    stream_get_contents($reusePortPipes[1]);
+    stream_get_contents($reusePortPipes[2]);
+    foreach ($reusePortPipes as $pipe) {
         fclose($pipe);
     }
-    $pythonExit = proc_close($checkPython);
-
-    if ($pythonExit === 0) {
-        $checkReusePort = proc_open(
-            ['python3', '-c', "import socket; raise SystemExit(0 if hasattr(socket, 'SO_REUSEPORT') else 1)"],
-            [
-                1 => ['pipe', 'w'],
-                2 => ['pipe', 'w'],
-            ],
-            $reusePortPipes
-        );
-        if (is_resource($checkReusePort)) {
-            stream_get_contents($reusePortPipes[1]);
-            stream_get_contents($reusePortPipes[2]);
-            foreach ($reusePortPipes as $pipe) {
-                fclose($pipe);
-            }
-            $reusePortExit = proc_close($checkReusePort);
-            if ($reusePortExit === 0) {
-                $probe = true;
-            }
-        }
-    }
+    $probe = proc_close($checkReusePort) === 0;
 }
 if (!$probe) {
     echo "skip python3 with socket.SO_REUSEPORT is required";

--- a/extension/tests/741-http1-listener-reuseport-opt-in-contract.phpt
+++ b/extension/tests/741-http1-listener-reuseport-opt-in-contract.phpt
@@ -11,12 +11,24 @@ if (!is_readable('/proc/net/tcp')) {
     return;
 }
 
-$probe = trim((string) shell_exec(
-    'command -v python3 >/dev/null 2>&1'
-    . ' && python3 -c ' . escapeshellarg("import socket; raise SystemExit(0 if hasattr(socket, 'SO_REUSEPORT') else 1)")
-    . ' >/dev/null 2>&1 && printf yes'
-));
-if ($probe !== 'yes') {
+$checkReusePort = @proc_open(
+    ['python3', '-c', "import socket; raise SystemExit(0 if hasattr(socket, 'SO_REUSEPORT') else 1)"],
+    [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ],
+    $reusePortPipes
+);
+$probe = false;
+if (is_resource($checkReusePort)) {
+    stream_get_contents($reusePortPipes[1]);
+    stream_get_contents($reusePortPipes[2]);
+    foreach ($reusePortPipes as $pipe) {
+        fclose($pipe);
+    }
+    $probe = proc_close($checkReusePort) === 0;
+}
+if (!$probe) {
     echo "skip python3 with socket.SO_REUSEPORT is required";
 }
 ?>

--- a/extension/tests/742-http1-reuseport-skipif-warning-free-contract.phpt
+++ b/extension/tests/742-http1-reuseport-skipif-warning-free-contract.phpt
@@ -1,0 +1,53 @@
+--TEST--
+King HTTP/1 reuseport SKIPIF probes stay warning-free
+--FILE--
+<?php
+$paths = [
+    __DIR__ . '/740-http1-listener-exclusive-bind-contract.phpt',
+    __DIR__ . '/741-http1-listener-reuseport-opt-in-contract.phpt',
+];
+
+function king_extract_skipif(string $path): string
+{
+    $source = (string) file_get_contents($path);
+    if (!preg_match('/--SKIPIF--\R(.*?)\R--FILE--/s', $source, $matches)) {
+        throw new RuntimeException('missing SKIPIF in ' . basename($path));
+    }
+    return $matches[1];
+}
+
+foreach ($paths as $path) {
+    $skipif = king_extract_skipif($path);
+
+    var_dump(!str_contains($skipif, "['command', '-v', 'python3']"));
+    var_dump(!str_contains($skipif, 'command -v python3'));
+    var_dump(str_contains($skipif, "@proc_open(\n    ['python3', '-c',"));
+
+    $warnings = [];
+    set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+        $warnings[] = $message;
+        return true;
+    });
+    ob_start();
+    try {
+        eval('?>' . $skipif);
+    } finally {
+        $output = trim((string) ob_get_clean());
+        restore_error_handler();
+    }
+
+    var_dump($warnings === []);
+    var_dump($output === '' || str_starts_with($output, 'skip '));
+}
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
  - Removed the bad command -v probe and directly run python3 -c ... with @proc_open(...).
  - Added 742-http1-reuseport-skipif-warning-free-contract.phpt to prevent this from regressing by checking the skip blocks do not use command probes and emit no warnings.