### PR TITLE
Add HTTP QUERY method support

### DIFF
--- a/extension/include/client/session.h
+++ b/extension/include/client/session.h
@@ -27,6 +27,7 @@ typedef struct _king_client_session {
     zend_string *config_quic_cc_algorithm;
     zend_string *config_storage_default_redundancy_mode;
     zend_string *config_cdn_cache_mode;
+    zend_string *config_cdn_allowed_http_methods;
     zend_string *config_dns_mode;
     zend_string *config_security_cors_allowed_origins;
     zend_string *config_otel_service_name;

--- a/extension/src/client/session/api/stats.inc
+++ b/extension/src/client/session/api/stats.inc
@@ -511,6 +511,11 @@ static void king_client_session_populate_stats(
         "config_cdn_cache_mode",
         zend_string_copy(session->config_cdn_cache_mode)
     );
+    add_assoc_str(
+        return_value,
+        "config_cdn_allowed_http_methods",
+        zend_string_copy(session->config_cdn_allowed_http_methods)
+    );
     add_assoc_bool(return_value, "config_dns_server_enable", session->config_dns_server_enable);
     add_assoc_str(
         return_value,

--- a/extension/src/client/session/state/config.inc
+++ b/extension/src/client/session/state/config.inc
@@ -65,6 +65,10 @@ void king_client_session_apply_config_resource(
         cfg->cdn.cache_mode
     );
     king_client_session_set_string(
+        &session->config_cdn_allowed_http_methods,
+        cfg->cdn.allowed_http_methods
+    );
+    king_client_session_set_string(
         &session->config_dns_mode,
         cfg->dns.mode
     );

--- a/extension/src/client/session/state/init.inc
+++ b/extension/src/client/session/state/init.inc
@@ -196,6 +196,10 @@ void king_client_session_init_config_state(king_client_session_t *session)
         king_native_cdn_config.cache_mode
     );
     king_client_session_set_string(
+        &session->config_cdn_allowed_http_methods,
+        king_native_cdn_config.allowed_http_methods
+    );
+    king_client_session_set_string(
         &session->config_dns_mode,
         king_smart_dns_config.mode
     );

--- a/extension/src/client/session/state/resource.inc
+++ b/extension/src/client/session/state/resource.inc
@@ -83,6 +83,10 @@ void king_client_session_free(void *session_ptr)
         zend_string_release(session->config_cdn_cache_mode);
     }
 
+    if (session->config_cdn_allowed_http_methods != NULL) {
+        zend_string_release(session->config_cdn_allowed_http_methods);
+    }
+
     if (session->config_dns_mode != NULL) {
         zend_string_release(session->config_dns_mode);
     }

--- a/extension/src/config/internal/object/snapshot_export.inc
+++ b/extension/src/config/internal/object/snapshot_export.inc
@@ -20,6 +20,11 @@ static void king_config_object_snapshot_to_array(zval *target, king_cfg_t *cfg)
     );
     add_assoc_bool(target, "cdn.enable", cfg->cdn.enable);
     add_assoc_string(target, "cdn.cache_mode", cfg->cdn.cache_mode != NULL ? cfg->cdn.cache_mode : "");
+    add_assoc_string(
+        target,
+        "cdn.allowed_http_methods",
+        cfg->cdn.allowed_http_methods != NULL ? cfg->cdn.allowed_http_methods : ""
+    );
     add_assoc_bool(target, "dns.server_enable", cfg->dns.server_enable);
     add_assoc_string(target, "dns.mode", cfg->dns.mode != NULL ? cfg->dns.mode : "");
     add_assoc_bool(target, "otel.enable", cfg->observability.enable);

--- a/extension/src/config/internal/object/snapshot_read.inc
+++ b/extension/src/config/internal/object/snapshot_read.inc
@@ -81,6 +81,20 @@ static zend_result king_config_object_snapshot_read(
     if (
         zend_string_equals_cstr(
             canonical_key,
+            "cdn.allowed_http_methods",
+            sizeof("cdn.allowed_http_methods") - 1
+        )
+    ) {
+        ZVAL_STRING(
+            return_value,
+            cfg->cdn.allowed_http_methods != NULL ? cfg->cdn.allowed_http_methods : ""
+        );
+        return SUCCESS;
+    }
+
+    if (
+        zend_string_equals_cstr(
+            canonical_key,
             "dns.server_enable",
             sizeof("dns.server_enable") - 1
         )

--- a/extension/src/config/native_cdn/config.c
+++ b/extension/src/config/native_cdn/config.c
@@ -103,7 +103,7 @@ int kg_config_native_cdn_apply_userland_config_to(
                 return FAILURE;
             }
         } else if (zend_string_equals_literal(key, "allowed_http_methods")) {
-            const char *allowed[] = {"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", NULL};
+            const char *allowed[] = {"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", "QUERY", NULL};
             if (kg_validate_comma_separated_string_from_allowlist(value, allowed, &target->allowed_http_methods) != SUCCESS) {
                 return FAILURE;
             }

--- a/extension/tests/755-cdn-query-method-config-contract.phpt
+++ b/extension/tests/755-cdn-query-method-config-contract.phpt
@@ -1,0 +1,41 @@
+--TEST--
+King CDN config accepts RFC 10008 QUERY in allowed HTTP methods
+--INI--
+king.security_allow_config_override=1
+--FILE--
+<?php
+$config = King\Config::new([
+    'cdn.enable' => true,
+    'cdn.allowed_http_methods' => 'GET, QUERY,HEAD',
+]);
+
+var_dump($config->get('cdn.allowed_http_methods'));
+
+$snapshot = $config->toArray();
+var_dump($snapshot['cdn.allowed_http_methods']);
+
+$session = king_connect('127.0.0.1', 443, $config);
+$stats = king_get_stats($session);
+
+var_dump($stats['config_binding']);
+var_dump($stats['config_cdn_enable']);
+var_dump($stats['config_cdn_allowed_http_methods']);
+
+king_close($session);
+
+try {
+    King\Config::new(['cdn.allowed_http_methods' => 'GET,TRACE']);
+    var_dump('no-exception');
+} catch (Throwable $e) {
+    var_dump(get_class($e));
+    var_dump($e->getMessage());
+}
+?>
+--EXPECTF--
+string(15) "GET, QUERY,HEAD"
+string(15) "GET, QUERY,HEAD"
+string(8) "resource"
+bool(true)
+string(15) "GET, QUERY,HEAD"
+string(24) "InvalidArgumentException"
+string(%d) "Invalid value provided. The value contains an unsupported algorithm or format."

--- a/extension/tests/756-http-query-method-client-wire-contract.phpt
+++ b/extension/tests/756-http-query-method-client-wire-contract.phpt
@@ -1,0 +1,166 @@
+--TEST--
+King HTTP/1 client sends RFC 10008 QUERY with request content on the wire
+--FILE--
+<?php
+function king_http1_query_756_start_server(): array
+{
+    $probe = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+    if ($probe === false) {
+        throw new RuntimeException("failed to reserve test port: $errstr");
+    }
+
+    $serverName = stream_socket_get_name($probe, false);
+    fclose($probe);
+    [, $port] = explode(':', $serverName, 2);
+
+    $script = tempnam(sys_get_temp_dir(), 'king-http1-query-756-');
+    file_put_contents($script, <<<'PHP'
+<?php
+function king_http1_query_756_read_request($conn): array
+{
+    $request = '';
+    while (!str_contains($request, "\r\n\r\n")) {
+        $chunk = fread($conn, 8192);
+        if ($chunk === '' || $chunk === false) {
+            break;
+        }
+        $request .= $chunk;
+    }
+
+    [$head, $body] = array_pad(explode("\r\n\r\n", $request, 2), 2, '');
+    $lines = $head === '' ? [] : explode("\r\n", $head);
+    $requestLine = array_shift($lines) ?? '';
+    $parts = explode(' ', $requestLine, 3);
+    $headers = [];
+    $contentLength = 0;
+
+    foreach ($lines as $line) {
+        if (!str_contains($line, ':')) {
+            continue;
+        }
+
+        [$name, $value] = explode(':', $line, 2);
+        $name = strtolower(trim($name));
+        $value = trim($value);
+        $headers[$name] = $value;
+
+        if ($name === 'content-length') {
+            $contentLength = (int) $value;
+        }
+    }
+
+    while (strlen($body) < $contentLength) {
+        $chunk = fread($conn, $contentLength - strlen($body));
+        if ($chunk === '' || $chunk === false) {
+            break;
+        }
+        $body .= $chunk;
+    }
+
+    return [$parts, $headers, $body];
+}
+
+$port = (int) $argv[1];
+$server = stream_socket_server("tcp://127.0.0.1:$port", $errno, $errstr);
+if ($server === false) {
+    fwrite(STDERR, "bind failed: $errstr\n");
+    exit(2);
+}
+
+fwrite(STDOUT, "READY\n");
+$conn = @stream_socket_accept($server, 5);
+if ($conn === false) {
+    fwrite(STDERR, "accept failed\n");
+    exit(3);
+}
+
+stream_set_timeout($conn, 5);
+[$parts, $headers, $body] = king_http1_query_756_read_request($conn);
+$payload = json_encode([
+    'method' => $parts[0] ?? '',
+    'path' => $parts[1] ?? '',
+    'content-type' => $headers['content-type'] ?? '',
+    'accept' => $headers['accept'] ?? '',
+    'body' => $body,
+], JSON_UNESCAPED_SLASHES);
+
+$response = "HTTP/1.1 200 OK\r\n"
+    . "Content-Type: application/json\r\n"
+    . "Content-Length: " . strlen($payload) . "\r\n"
+    . "Connection: close\r\n\r\n"
+    . $payload;
+
+fwrite($conn, $response);
+fclose($conn);
+fclose($server);
+PHP);
+
+    $command = escapeshellarg(PHP_BINARY) . ' -n ' . escapeshellarg($script) . ' ' . (int) $port;
+    $process = proc_open($command, [
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ], $pipes);
+
+    if (!is_resource($process)) {
+        @unlink($script);
+        throw new RuntimeException('failed to launch local HTTP/1 QUERY test server');
+    }
+
+    $ready = fgets($pipes[1]);
+    if ($ready !== "READY\n") {
+        $stderr = stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        proc_close($process);
+        @unlink($script);
+        throw new RuntimeException('local HTTP/1 QUERY test server failed: ' . trim($stderr));
+    }
+
+    return [$process, $pipes, $script, (int) $port];
+}
+
+function king_http1_query_756_stop_server(array $server): void
+{
+    [$process, $pipes, $script] = $server;
+    foreach ($pipes as $pipe) {
+        fclose($pipe);
+    }
+    proc_close($process);
+    @unlink($script);
+}
+
+$server = king_http1_query_756_start_server();
+try {
+    $response = king_client_send_request(
+        'http://127.0.0.1:' . $server[3] . '/search?stable=1',
+        'QUERY',
+        [
+            'Content-Type' => 'application/query+json',
+            'Accept' => 'application/json',
+        ],
+        '{"select":["invoice"],"limit":20}',
+        ['preferred_protocol' => 'http1.1']
+    );
+} finally {
+    king_http1_query_756_stop_server($server);
+}
+
+$echo = json_decode($response['body'], true, flags: JSON_THROW_ON_ERROR);
+
+var_dump($response['status']);
+var_dump($response['protocol']);
+var_dump($echo['method']);
+var_dump($echo['path']);
+var_dump($echo['content-type']);
+var_dump($echo['accept']);
+var_dump($echo['body']);
+?>
+--EXPECT--
+int(200)
+string(8) "http/1.1"
+string(5) "QUERY"
+string(16) "/search?stable=1"
+string(22) "application/query+json"
+string(16) "application/json"
+string(33) "{"select":["invoice"],"limit":20}"

--- a/stubs/king.php
+++ b/stubs/king.php
@@ -619,7 +619,8 @@ namespace {
      * The canonical runtime-build override surface uses namespaced keys
      * under `quic.`, `tls.`, `http2.`, `tcp.`, `autoscale.`, `mcp.`,
      * `orchestrator.`, `geometry.`, `smartcontract.`, `ssh.`,
-     * `storage.`, `cdn.`, `dns.`, and `otel.`.
+     * `storage.`, `cdn.`, `dns.`, and `otel.`. The CDN method override
+     * accepts standard HTTP methods including RFC 10008 `QUERY`.
      * @param array<string,mixed>|null $options
      * @return resource|false
      * @throws \King\RuntimeException


### PR DESCRIPTION
## Summary

- add RFC 10008 QUERY to the native CDN allowed HTTP method configuration
- expose cdn.allowed_http_methods through King\Config snapshots and session stats
- add focused PHPT contracts for QUERY config handling and HTTP/1 wire dispatch with a request body

## Validation

Already run before this PR:
- make build
- bash infra/scripts/test-extension.sh tests/755-cdn-query-method-config-contract.phpt tests/756-http-query-method-client-wire-contract.phpt tests/121-config-resource-namespaced-data-observability-overrides.phpt tests/123-config-resource-empty-snapshot-follows-ini.phpt
- make stub-parity