### PR TITLE
Release v1.0.9 beta

### DIFF
--- a/extension/include/php_king.h
+++ b/extension/include/php_king.h
@@ -29,7 +29,7 @@
  * Extension Version and Global Constants
  */
 #ifndef PHP_KING_VERSION
-#  define PHP_KING_VERSION      "1.0.6"
+#  define PHP_KING_VERSION      "1.0.9"
 #endif
 
 #ifndef KING_MAX_TICKET_SIZE


### PR DESCRIPTION
## Summary

- bump the native King extension version to 1.0.9 for the v1.0.9-beta release line
- use the release branch shape expected by the release-publish workflow: develop/v1.0.9-beta

## Release target

- tag expected from workflow: v1.0.9-beta
- target base: main

## Validation

No local test run in this turn; this is a version-only release branch and the release workflow will build/package from the merged main commit.