### PR TITLE
Fix Ubuntu PHP runtime CA bootstrap

### DIFF
--- a/infra/scripts/install-ubuntu-php-runtime.sh
+++ b/infra/scripts/install-ubuntu-php-runtime.sh
@@ -9,14 +9,21 @@ if [[ -z "${PHP_VERSION}" ]]; then
     exit 1
 fi
 
-for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
-    if [[ -f "${source_file}" ]]; then
-        sed -i \
-            -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
-            -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
-            "${source_file}"
-    fi
-done
+normalize_ubuntu_sources_to_scheme() {
+    local scheme="$1"
+    local source_file=""
+
+    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+        if [[ -f "${source_file}" ]]; then
+            sed -i \
+                -e "s|https\\?://archive.ubuntu.com/ubuntu|${scheme}://archive.ubuntu.com/ubuntu|g" \
+                -e "s|https\\?://security.ubuntu.com/ubuntu|${scheme}://security.ubuntu.com/ubuntu|g" \
+                "${source_file}"
+        fi
+    done
+}
+
+normalize_ubuntu_sources_to_scheme http
 
 apt-get \
     -o Acquire::Retries=5 \
@@ -31,6 +38,15 @@ apt-get install -y --no-install-recommends \
     gnupg \
     libcurl3t64-gnutls \
     libuuid1
+
+normalize_ubuntu_sources_to_scheme https
+
+apt-get \
+    -o Acquire::Retries=5 \
+    -o Acquire::http::Timeout=30 \
+    -o Acquire::https::Timeout=30 \
+    -o Acquire::ForceIPv4=true \
+    update
 
 mkdir -p /usr/share/keyrings
 curl --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors -fsSL \


### PR DESCRIPTION
## Summary

- keep the first Ubuntu apt bootstrap reachable before ca-certificates exists
- install ca-certificates/curl/gnupg/libcurl from the base Ubuntu sources first
- switch Ubuntu sources back to HTTPS before adding the Ondrej PHP PPA and installing PHP runtime packages

## Root cause

The runtime base image script rewrote Ubuntu sources to HTTPS before installing ca-certificates. On fresh Ubuntu base images this can make apt unable to verify archive.ubuntu.com/security.ubuntu.com, which then makes packages like ca-certificates, curl, gnupg and libcurl appear unavailable.

## Validation

Static diff check only in this turn. No Docker/CI rerun was started from here.