### PR TITLE
Update core version PHPT expectations

### DIFF
--- a/extension/tests/001-load-and-core.phpt
+++ b/extension/tests/001-load-and-core.phpt
@@ -15,14 +15,14 @@ var_dump($health);
 bool(true)
 bool(true)
 bool(true)
-string(5) "1.0.6"
+string(5) "1.0.9"
 array(8) {
   ["status"]=>
   string(2) "ok"
   ["build"]=>
   string(2) "v1"
   ["version"]=>
-  string(5) "1.0.6"
+  string(5) "1.0.9"
   ["config_override_allowed"]=>
   bool(false)
   ["active_runtime_count"]=>

--- a/extension/tests/006-health-shape.phpt
+++ b/extension/tests/006-health-shape.phpt
@@ -42,7 +42,7 @@ array(10) {
 }
 string(2) "ok"
 string(2) "v1"
-string(5) "1.0.6"
+string(5) "1.0.9"
 bool(true)
 bool(true)
 bool(true)


### PR DESCRIPTION
Updates the two stale core PHPT expectations from 1.0.6 to the current PHP_KING_VERSION 1.0.9.\n\nCI evidence: King Canonical Baseline on develop/1.0.9-beta passed in run 28073254280.