### PR TITLE
Address AI review findings

### DIFF
--- a/extension/tests/742-http1-reuseport-skipif-warning-free-contract.phpt
+++ b/extension/tests/742-http1-reuseport-skipif-warning-free-contract.phpt
@@ -20,7 +20,17 @@ function king_run_skipif_isolated(string $skipif): array
 {
     $warnings = [];
     $process = proc_open(
-        [PHP_BINARY],
+        [
+            PHP_BINARY,
+            '-d',
+            'disable_functions=',
+            '-d',
+            'display_errors=1',
+            '-d',
+            'display_startup_errors=1',
+            '-d',
+            'error_reporting=' . E_ALL,
+        ],
         [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],

--- a/extension/tests/server_websocket_wire_helper.inc
+++ b/extension/tests/server_websocket_wire_helper.inc
@@ -371,11 +371,10 @@ function king_server_websocket_wire_raw_client_send_text($socket, string $payloa
         $frame .= chr(0x80 | 127) . pack('N2', $high, $low);
     }
 
-    $maskedBytes = [];
+    $maskedPayload = $payload;
     for ($i = 0; $i < $payloadLength; $i++) {
-        $maskedBytes[] = $payload[$i] ^ $mask[$i % 4];
+        $maskedPayload[$i] = $payload[$i] ^ $mask[$i % 4];
     }
-    $maskedPayload = implode('', $maskedBytes);
 
     $frame .= $mask . $maskedPayload;
 


### PR DESCRIPTION
## Summary
- run isolated SKIPIF probes with explicit PHPT-style ini overrides
- mask WebSocket test frames in a string buffer instead of a per-byte PHP array

## Verification
- GitHub Actions: King Canonical Baseline run 28074680265 passed on develop/1.0.9-beta