### PR TITLE
Release v1.0.10-beta publish fix

### DIFF
--- a/.github/workflows/release-merge-publish.yml
+++ b/.github/workflows/release-merge-publish.yml
@@ -8,6 +8,7 @@ on:
       - closed
 
 permissions:
+  actions: write
   contents: write
   pull-requests: read
   packages: write
@@ -576,7 +577,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout release merge commit
         uses: actions/checkout@v6
@@ -638,6 +639,21 @@ jobs:
         working-directory: packages/iibin
         run: npm run typecheck && npm run build
 
+      - name: Pack package release asset
+        working-directory: packages/iibin
+        run: |
+          set -euo pipefail
+          mkdir -p ../../release-assets
+          npm pack --pack-destination ../../release-assets
+
+      - name: Upload package archive to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve-release-merge.outputs.release-tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" release-assets/*.tgz --clobber
+
       - name: Check if package version already exists
         id: iibin-npm-check
         env:
@@ -660,10 +676,24 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
-            echo "NPM_TOKEN secret is required to publish @intelligentintern/iibin." >&2
-            exit 1
+            echo "::warning::NPM_TOKEN is not configured; the verified IIBIN package archive remains attached to the GitHub release."
+            exit 0
           fi
-          npm publish --access public --tag "${NPM_TAG}"
+
+          publish_log="$(mktemp)"
+          set +e
+          npm publish --access public --tag "${NPM_TAG}" >"${publish_log}" 2>&1
+          status="$?"
+          set -e
+          cat "${publish_log}"
+          if [[ "${status}" -eq 0 ]]; then
+            exit 0
+          fi
+          if grep -Eq 'npm error code E(401|403|404)' "${publish_log}"; then
+            echo "::warning::npm rejected @intelligentintern/iibin publish with an authorization or package-scope error; the verified archive remains attached to the GitHub release."
+            exit 0
+          fi
+          exit "${status}"
 
   dockerhub-runtime-release:
     name: Build and push Docker Hub runtime image

--- a/extension/include/php_king/constants.h
+++ b/extension/include/php_king/constants.h
@@ -6,7 +6,7 @@
 #define KING_PHP_KING_CONSTANTS_H
 
 #ifndef PHP_KING_VERSION
-#  define PHP_KING_VERSION "1.0.9"
+#  define PHP_KING_VERSION "1.0.10-beta"
 #endif
 
 #ifndef KING_MAX_TICKET_SIZE

--- a/extension/tests/001-load-and-core.phpt
+++ b/extension/tests/001-load-and-core.phpt
@@ -15,14 +15,14 @@ var_dump($health);
 bool(true)
 bool(true)
 bool(true)
-string(5) "1.0.9"
+string(11) "1.0.10-beta"
 array(8) {
   ["status"]=>
   string(2) "ok"
   ["build"]=>
   string(2) "v1"
   ["version"]=>
-  string(5) "1.0.9"
+  string(11) "1.0.10-beta"
   ["config_override_allowed"]=>
   bool(false)
   ["active_runtime_count"]=>

--- a/extension/tests/006-health-shape.phpt
+++ b/extension/tests/006-health-shape.phpt
@@ -42,7 +42,7 @@ array(10) {
 }
 string(2) "ok"
 string(2) "v1"
-string(5) "1.0.9"
+string(11) "1.0.10-beta"
 bool(true)
 bool(true)
 bool(true)

--- a/infra/scripts/resolve-docker-buildx-cache.sh
+++ b/infra/scripts/resolve-docker-buildx-cache.sh
@@ -75,7 +75,7 @@ write_scalar_output() {
 }
 
 cache_from="type=gha,scope=${SCOPE}"
-cache_to="type=gha,mode=max,scope=${SCOPE}"
+cache_to="type=gha,mode=max,scope=${SCOPE},ignore-error=true"
 local_root="${KING_CI_LOCAL_DOCKER_BUILDX_CACHE_DIR:-}"
 use_local="false"
 local_dir=""


### PR DESCRIPTION
Fixes the v1.0.10-beta release publish path without squashing commits.\n\n- Align PHP_KING_VERSION with the v1.0.10-beta release branch.\n- Make Buildx cache export non-blocking when GitHub cache reservation fails.\n- Keep the verified IIBIN npm archive on the GitHub release when npm registry publish is unavailable due token/scope authorization.